### PR TITLE
Implemented stop, start and reboot operations for servers

### DIFF
--- a/lib/fog/softlayer/compute.rb
+++ b/lib/fog/softlayer/compute.rb
@@ -57,6 +57,12 @@ module Fog
       request :get_vm_tags
       request :get_vm
       request :get_vms
+      request :power_off_bare_metal_server
+      request :power_off_vm
+      request :power_on_bare_metal_server
+      request :power_on_vm
+      request :reboot_bare_metal_server
+      request :reboot_vm
       request :update_key_pair
 
       # The Mock Service allows you to run a fake instance of the Service

--- a/lib/fog/softlayer/models/compute/server.rb
+++ b/lib/fog/softlayer/models/compute/server.rb
@@ -259,12 +259,12 @@ module Fog
         end
 
         def reboot(use_hard_reboot = true)
-          requires :identity
           if bare_metal?
             service.reboot_bare_metal_server(id, use_hard_reboot)
           else
             service.reboot_vm(id, use_hard_reboot)
           end
+          true
         end
 
         def ssh_password
@@ -279,32 +279,32 @@ module Fog
         end
 
         def start
-          requires :identity
           if bare_metal?
             service.power_on_bare_metal_server(id)
           else
             service.power_on_vm(id)
           end
+          true
         end
 
         # Hard power off
         def stop
-          requires :identity
           if bare_metal?
             service.power_off_bare_metal_server(id)
           else
             service.power_off_vm(id, true)
           end
+          true
         end
 
         # Soft power off
         def shutdown
-          requires :identity
           if bare_metal?
             raise Fog::Errors::Error.new('Shutdown not supported on baremetal servers. Use #stop.')
           else
             service.power_off_vm(id, false)
           end
+          true
         end
 
         def state

--- a/lib/fog/softlayer/models/compute/server.rb
+++ b/lib/fog/softlayer/models/compute/server.rb
@@ -259,7 +259,12 @@ module Fog
         end
 
         def reboot(use_hard_reboot = true)
-          # TODO: implement
+          requires :identity
+          if bare_metal?
+            service.reboot_bare_metal_server(id, use_hard_reboot)
+          else
+            service.reboot_vm(id, use_hard_reboot)
+          end
         end
 
         def ssh_password
@@ -274,19 +279,32 @@ module Fog
         end
 
         def start
-          # TODO: implement
-
-          #requires :identity
-          #service.start_server(identity)
-          true
+          requires :identity
+          if bare_metal?
+            service.power_on_bare_metal_server(id)
+          else
+            service.power_on_vm(id)
+          end
         end
 
+        # Hard power off
         def stop
-          # TODO: implement
+          requires :identity
+          if bare_metal?
+            service.power_off_bare_metal_server(id)
+          else
+            service.power_off_vm(id, true)
+          end
         end
 
+        # Soft power off
         def shutdown
-          # TODO: implement
+          requires :identity
+          if bare_metal?
+            raise Fog::Errors::Error.new('Shutdown not supported on baremetal servers. Use #stop.')
+          else
+            service.power_off_vm(id, false)
+          end
         end
 
         def state

--- a/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Softlayer
+
+      class Mock
+
+        # Stop a BM server
+        # @param [Integer] id
+        # @return [Excon::Response]
+        def power_off_bare_metal_server(id)
+          # TODO: implement
+        end
+      end
+
+      class Real
+
+        def power_off_bare_metal_server(id)
+          request(:virtual_guest, "#{id.to_s}/powerOff", :http_method => :GET)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
@@ -15,7 +15,7 @@ module Fog
       class Real
 
         def power_off_bare_metal_server(id)
-          request(:virtual_guest, "#{id.to_s}/powerOff", :http_method => :GET)
+          request(:hardware_server, "#{id.to_s}/powerOff", :http_method => :GET)
         end
 
       end

--- a/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
@@ -8,7 +8,19 @@ module Fog
         # @param [Integer] id
         # @return [Excon::Response]
         def power_off_bare_metal_server(id)
-          # TODO: implement
+          response = Excon::Response.new
+          response.status = 200
+          found = self.get_bare_metal_servers.body.map{|server| server['id']}.include?(id)
+          if not found
+            response.status = 404
+            response.body = {
+              "error" => "Unable to find object with id of '#{id}'.",
+              "code" => "SoftLayer_Exception_ObjectNotFound"
+            }
+          else
+            response.body = true
+          end
+          response
         end
       end
 

--- a/lib/fog/softlayer/requests/compute/power_off_vm.rb
+++ b/lib/fog/softlayer/requests/compute/power_off_vm.rb
@@ -8,7 +8,19 @@ module Fog
         # @param [Integer] id
         # @return [Excon::Response]
         def power_off_vm(id, use_hard_poweroff)
-          # TODO: implement
+          response = Excon::Response.new
+          response.status = 200
+          found = self.get_vms.body.map{|server| server['id']}.include?(id)
+          if not found
+            response.status = 404
+            response.body = {
+              "error" => "Unable to find object with id of '#{id}'.",
+              "code" => "SoftLayer_Exception_ObjectNotFound"
+            }
+          else
+            response.body = true
+          end
+          response
         end
       end
 

--- a/lib/fog/softlayer/requests/compute/power_off_vm.rb
+++ b/lib/fog/softlayer/requests/compute/power_off_vm.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Compute
+    class Softlayer
+
+      class Mock
+
+        # Stop a VM
+        # @param [Integer] id
+        # @return [Excon::Response]
+        def power_off_vm(id, use_hard_poweroff)
+          # TODO: implement
+        end
+      end
+
+      class Real
+
+        def power_off_vm(id, use_hard_poweroff)
+          if use_hard_poweroff
+            request(:virtual_guest, "#{id.to_s}/powerOff", :http_method => :GET)
+          else
+            request(:virtual_guest, "#{id.to_s}/powerOffSoft", :http_method => :GET)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
@@ -8,7 +8,19 @@ module Fog
         # @param [Integer] id
         # @return [Excon::Response]
         def power_on_bare_metal_server(id)
-          # TODO: implement
+          response = Excon::Response.new
+          response.status = 200
+          found = self.get_bare_metal_servers.body.map{|server| server['id']}.include?(id)
+          if not found
+            response.status = 404
+            response.body = {
+              "error" => "Unable to find object with id of '#{id}'.",
+              "code" => "SoftLayer_Exception_ObjectNotFound"
+            }
+          else
+            response.body = true
+          end
+          response
         end
       end
 

--- a/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
@@ -15,7 +15,7 @@ module Fog
       class Real
 
         def power_on_bare_metal_server(id)
-          request(:virtual_guest, "#{id.to_s}/powerOn", :http_method => :GET)
+          request(:hardware_server, "#{id.to_s}/powerOn", :http_method => :GET)
         end
 
       end

--- a/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Softlayer
+
+      class Mock
+
+        # Starts a BM server
+        # @param [Integer] id
+        # @return [Excon::Response]
+        def power_on_bare_metal_server(id)
+          # TODO: implement
+        end
+      end
+
+      class Real
+
+        def power_on_bare_metal_server(id)
+          request(:virtual_guest, "#{id.to_s}/powerOn", :http_method => :GET)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/softlayer/requests/compute/power_on_vm.rb
+++ b/lib/fog/softlayer/requests/compute/power_on_vm.rb
@@ -8,7 +8,19 @@ module Fog
         # @param [Integer] id
         # @return [Excon::Response]
         def power_on_vm(id)
-          # TODO: implement
+          response = Excon::Response.new
+          response.status = 200
+          found = self.get_vms.body.map{|server| server['id']}.include?(id)
+          if not found
+            response.status = 404
+            response.body = {
+              "error" => "Unable to find object with id of '#{id}'.",
+              "code" => "SoftLayer_Exception_ObjectNotFound"
+            }
+          else
+            response.body = true
+          end
+          response
         end
       end
 

--- a/lib/fog/softlayer/requests/compute/power_on_vm.rb
+++ b/lib/fog/softlayer/requests/compute/power_on_vm.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Softlayer
+
+      class Mock
+
+        # Powers on a VM
+        # @param [Integer] id
+        # @return [Excon::Response]
+        def power_on_vm(id)
+          # TODO: implement
+        end
+      end
+
+      class Real
+
+        def power_on_vm(id)
+          request(:virtual_guest, "#{id.to_s}/powerOn", :http_method => :GET)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
@@ -16,9 +16,9 @@ module Fog
 
         def reboot_bare_metal_server(id, use_hard_reboot)
           if use_hard_reboot
-            request(:virtual_guest, "#{id.to_s}/rebootHard", :http_method => :GET)
+            request(:hardware_server, "#{id.to_s}/rebootHard", :http_method => :GET)
           else
-            request(:virtual_guest, "#{id.to_s}/rebootSoft", :http_method => :GET)
+            request(:hardware_server, "#{id.to_s}/rebootSoft", :http_method => :GET)
           end
         end
 

--- a/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
@@ -8,7 +8,19 @@ module Fog
         # @param [Integer] id
         # @return [Excon::Response]
         def reboot_bare_metal_server(id, use_hard_reboot)
-          # TODO: implement
+          response = Excon::Response.new
+          response.status = 200
+          found = self.get_bare_metal_servers.body.map{|server| server['id']}.include?(id)
+          if not found
+            response.status = 404
+            response.body = {
+              "error" => "Unable to find object with id of '#{id}'.",
+              "code" => "SoftLayer_Exception_ObjectNotFound"
+            }
+          else
+            response.body = true
+          end
+          response
         end
       end
 

--- a/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Compute
+    class Softlayer
+
+      class Mock
+
+        # Reboots a BM server
+        # @param [Integer] id
+        # @return [Excon::Response]
+        def reboot_bare_metal_server(id, use_hard_reboot)
+          # TODO: implement
+        end
+      end
+
+      class Real
+
+        def reboot_bare_metal_server(id, use_hard_reboot)
+          if use_hard_reboot
+            request(:virtual_guest, "#{id.to_s}/rebootHard", :http_method => :GET)
+          else
+            request(:virtual_guest, "#{id.to_s}/rebootSoft", :http_method => :GET)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/softlayer/requests/compute/reboot_vm.rb
+++ b/lib/fog/softlayer/requests/compute/reboot_vm.rb
@@ -8,7 +8,19 @@ module Fog
         # @param [Integer] id
         # @return [Excon::Response]
         def reboot_vm(id, use_hard_reboot)
-          # TODO: implement
+          response = Excon::Response.new
+          response.status = 200
+          found = self.get_vms.body.map{|server| server['id']}.include?(id)
+          if not found
+            response.status = 404
+            response.body = {
+              "error" => "Unable to find object with id of '#{id}'.",
+              "code" => "SoftLayer_Exception_ObjectNotFound"
+            }
+          else
+            response.body = true
+          end
+          response
         end
       end
 

--- a/lib/fog/softlayer/requests/compute/reboot_vm.rb
+++ b/lib/fog/softlayer/requests/compute/reboot_vm.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Compute
+    class Softlayer
+
+      class Mock
+
+        # Reboots a VM
+        # @param [Integer] id
+        # @return [Excon::Response]
+        def reboot_vm(id, use_hard_reboot)
+          # TODO: implement
+        end
+      end
+
+      class Real
+
+        def reboot_vm(id, use_hard_reboot)
+          if use_hard_reboot
+            request(:virtual_guest, "#{id.to_s}/rebootHard", :http_method => :GET)
+          else
+            request(:virtual_guest, "#{id.to_s}/rebootSoft", :http_method => :GET)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/tests/softlayer/models/compute/server_tests.rb
+++ b/tests/softlayer/models/compute/server_tests.rb
@@ -64,6 +64,29 @@ Shindo.tests("Fog::Compute[:softlayer] | Server model", ["softlayer"]) do
       returns(true) { @vm.save }
     end
 
+    tests("#start") do
+      returns(true) { @vm.start }
+      returns(true) { @bmc.start }
+    end
+
+    tests("#stop") do
+      returns(true) { @vm.stop }
+      returns(true) { @bmc.stop }
+    end
+
+    tests("#shutdown") do
+      returns(true) { @vm.shutdown }
+    end
+
+    tests("#reboot") do
+      returns(true) { @vm.reboot }
+      returns(true) { @bmc.reboot }
+      returns(true) { @vm.reboot(true) }
+      returns(true) { @bmc.reboot(true) }
+      returns(true) { @vm.reboot(false) }
+      returns(true) { @bmc.reboot(false) }
+    end
+
   end
 
   tests ("failure") do
@@ -97,6 +120,11 @@ Shindo.tests("Fog::Compute[:softlayer] | Server model", ["softlayer"]) do
     # should not allow a second save
     tests("#save").raises(Fog::Errors::Error) do
       @vm.save
+    end
+
+    # bare metal servers dont allow shutdown
+    tests("#shutdown").raises(Fog::Errors::Error) do
+      @bmc.shutdown
     end
 
     tests("#destroy").raises(ArgumentError) do

--- a/tests/softlayer/requests/compute/bmc_tests.rb
+++ b/tests/softlayer/requests/compute/bmc_tests.rb
@@ -33,6 +33,30 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
       end
     end
 
+    tests("#power_on_bare_metal_server('#{@server_id})'") do
+      response = @sl_connection.power_on_bare_metal_server(@server_id)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
+    tests("#power_off_bare_metal_server('#{@server_id})'") do
+      response = @sl_connection.power_off_bare_metal_server(@server_id)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
+    tests("#reboot_bare_metal_server('#{@server_id})', true") do
+      response = @sl_connection.reboot_bare_metal_server(@server_id, true)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
+    tests("#reboot_bare_metal_server('#{@server_id})', false") do
+      response = @sl_connection.reboot_bare_metal_server(@server_id, false)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
     tests("#delete_bare_metal_server('#{@server_id})'") do
       response = @sl_connection.delete_bare_metal_server(@server_id)
       data_matches_schema(true) {response.body}
@@ -51,6 +75,30 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
 
     tests("#create_bare_metal_server(#{[@bmc]}").raises(ArgumentError) do
       @sl_connection.create_bare_metal_server([@bmc])
+    end
+
+    tests("#power_on_bare_metal_server('#{bmc}')") do
+      response = @sl_connection.power_on_bare_metal_server(bmc)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404){ response.status }
+    end
+
+    tests("#power_off_bare_metal_server('#{bmc}')") do
+      response = @sl_connection.power_off_bare_metal_server(bmc)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404){ response.status }
+    end
+
+    tests("#reboot_bare_metal_server('#{bmc}', true)") do
+      response = @sl_connection.reboot_bare_metal_server(bmc, true)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404){ response.status }
+    end
+
+    tests("#reboot_bare_metal_server('#{bmc}', false)") do
+      response = @sl_connection.reboot_bare_metal_server(bmc, false)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404){ response.status }
     end
 
     tests("#delete_bare_metal_server('99999999999999')'") do

--- a/tests/softlayer/requests/compute/vm_tests.rb
+++ b/tests/softlayer/requests/compute/vm_tests.rb
@@ -50,6 +50,36 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
       #data_matches_schema(Softlayer::Compute::Formats::VirtualGuest::SERVER) { vm }
     end
 
+    tests("#power_on_vm(#{@vm_id})") do
+      response = @sl_connection.power_on_vm(@vm_id)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
+    tests("#power_off_vm(#{@vm_id}, false)") do
+      response = @sl_connection.power_off_vm(@vm_id, false)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
+    tests("#power_off_vm(#{@vm_id}, true)") do
+      response = @sl_connection.power_off_vm(@vm_id, true)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
+    tests("#reboot_vm(#{@vm_id}, false)") do
+      response = @sl_connection.reboot_vm(@vm_id, false)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
+    tests("#reboot_vm(#{@vm_id}, true)") do
+      response = @sl_connection.reboot_vm(@vm_id, true)
+      data_matches_schema(true) {response.body}
+      data_matches_schema(200) {response.status}
+    end
+
     tests("#delete_vm('#{@vm_id})'") do
       response = @sl_connection.delete_vm(@vm_id)
       data_matches_schema(true) {response.body}
@@ -78,6 +108,36 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
 
     tests("#create_vm(#{@vms}").raises(ArgumentError) do
       @sl_connection.create_vm(@vms)
+    end
+
+    tests("#power_on_vm('99999999999999')") do
+      response = @sl_connection.power_on_vm(99999999999999)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404) {response.status}
+    end
+
+    tests("#power_off_vm('99999999999999', true)") do
+      response = @sl_connection.power_off_vm(99999999999999, true)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404) {response.status}
+    end
+
+    tests("#power_off_vm('99999999999999', false)") do
+      response = @sl_connection.power_off_vm(99999999999999, false)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404) {response.status}
+    end
+
+    tests("#reboot_vm('99999999999999', true)") do
+      response = @sl_connection.reboot_vm(99999999999999, true)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404) {response.status}
+    end
+
+    tests("#reboot_vm('99999999999999', false)") do
+      response = @sl_connection.reboot_vm(99999999999999, false)
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404) {response.status}
     end
 
     tests("#delete_vm('99999999999999')'") do


### PR DESCRIPTION
Service requests implemented for 'powerOn', 'powerOff' and 'reboot' methods, on virtual and baremetal instances.

Model 'server' methods 'start', 'stop', 'shutdown' and 'reboot' implemented.

Refers to issue #39 .
