### PR TITLE
feature/Add option for get a server by ip

### DIFF
--- a/examples/compute.md
+++ b/examples/compute.md
@@ -27,6 +27,15 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
    server.state # => 'Running', 'Stopped', 'Terminated', etc.
    ```
 
+1. Get a server's details using ip address
+
+   ```ruby
+   server = @sl.servers.get_by_ip(<server ip>)
+   server.name # => 'hostname.example.com'
+   server.created_at # => DateTime the server was created
+   server.state # => 'Running', 'Stopped', 'Terminated', etc.
+   ```
+
 1. Get all servers tagged with certain tags.
 
 	```ruby

--- a/lib/fog/softlayer/compute.rb
+++ b/lib/fog/softlayer/compute.rb
@@ -49,12 +49,14 @@ module Fog
       request :describe_tags
       request :get_bare_metal_create_options
       request :get_bare_metal_server
+      request :get_bare_metal_server_by_ip
       request :get_bare_metal_servers
       request :get_bare_metal_tags
       request :get_key_pair
       request :get_key_pairs
       request :get_references_by_tag_name
       request :get_tag
+      request :get_virtual_guest_by_ip
       request :get_virtual_guest_create_options
       request :get_vm_tags
       request :get_vm

--- a/lib/fog/softlayer/models/compute/servers.rb
+++ b/lib/fog/softlayer/models/compute/servers.rb
@@ -39,6 +39,23 @@ module Fog
           nil
         end
 
+        ## Get a SoftLayer server by ip.
+        #
+        def get_by_ip(ip)
+          return nil if ip.blank?
+          response = service.get_virtual_guest_by_ip(ip)
+          bare_metal = false
+          if response.status == 404 # we didn't find it as a VM, look for a BMC server
+            response = service.get_bare_metal_server_by_ip(ip)
+            bare_metal = true
+          end
+          data = response.body
+          data['bare_metal'] = bare_metal
+          new.merge_attributes(data)
+        rescue Excon::Errors::NotFound
+          nil
+        end
+
         def bootstrap(options={})
           server = service.create(options)
           server.wait_for { ready? }

--- a/lib/fog/softlayer/requests/compute/create_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/create_bare_metal_server.rb
@@ -58,6 +58,7 @@ module Fog
                 'modifyDate' => nil,
                 'startCpus' => nil,
                 'statusId' => 1001,
+                'primaryIpAddress' => Fog::Mock.random_ip,
                 'globalIdentifier' => Fog::Softlayer.mock_global_identifier
             }
           rescue MissingRequiredParameter

--- a/lib/fog/softlayer/requests/compute/create_vms.rb
+++ b/lib/fog/softlayer/requests/compute/create_vms.rb
@@ -63,6 +63,7 @@ module Fog
                 'statusId' => 1001,
                 'globalIdentifier' => Fog::Softlayer.mock_global_identifier,
                 'operatingSystem' => {},
+                'primaryIpAddress' => Fog::Mock.random_ip,
                 'tagReferences' => []
             }
 

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_server_by_ip.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_server_by_ip.rb
@@ -10,7 +10,7 @@ module Fog
       class Mock
         def get_bare_metal_server_by_ip(ip_address)
           response = Excon::Response.new
-          response.body = @bare_metal_servers.map {|vm| vm if vm['public_ip_address'] == ip_address.to_s }.compact.first || {}
+          response.body = @bare_metal_servers.map {|vm| vm if vm['primaryIpAddress'] == ip_address.to_s }.compact.first || {}
           response.status = response.body.empty? ? 404 : 200
           if response.status == 404
             response.body = {

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_server_by_ip.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_server_by_ip.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Matheus Francisco Barra Mina (<mfbmina@gmail.com>)
+# © Copyright IBM Corporation 2015.
+#
+# LICENSE: MIT (http://opensource.org/licenses/MIT)
+#
+module Fog
+  module Compute
+    class Softlayer
+      class Mock
+        def get_bare_metal_server_by_ip(ip_address)
+          response = Excon::Response.new
+          response.body = @bare_metal_servers.map {|vm| vm if vm['public_ip_address'] == ip_address.to_s }.compact.first || {}
+          response.status = response.body.empty? ? 404 : 200
+          if response.status == 404
+            response.body = {
+              "error"=>"Unable to find object with ip of '#{ip_address}'.",
+              "code"=>"SoftLayer_Exception_ObjectNotFound"
+            }
+          end
+          response
+        end
+      end
+
+      class Real
+        def get_bare_metal_server_by_ip(ip_address)
+          request(:hardware_server, :findByIpAddress, :body => "#{ip_address}", :http_method => :POST, :query => 'objectMask=mask[datacenter,tagReferences,memory,provisionDate,processorCoreAmount,hardDrives,datacenter,hourlyBillingFlag,operatingSystem.softwareLicense.softwareDescription.referenceCode,sshKeys.id,privateNetworkOnlyFlag,userData,frontendNetworkComponents,backendNetworkComponents]')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/softlayer/requests/compute/get_virtual_guest_by_ip.rb
+++ b/lib/fog/softlayer/requests/compute/get_virtual_guest_by_ip.rb
@@ -10,7 +10,7 @@ module Fog
       class Mock
         def get_virtual_guest_by_ip(ip_address)
           response = Excon::Response.new
-          response.body = @virtual_guests.map {|vm| vm if vm['public_ip_address'] == ip_address }.compact.first || {}
+          response.body = @virtual_guests.map {|vm| vm if vm['primaryIpAddress'] == ip_address }.compact.first || {}
           response.status = response.body.empty? ? 404 : 200
           if response.status == 404
             response.body = {

--- a/lib/fog/softlayer/requests/compute/get_virtual_guest_by_ip.rb
+++ b/lib/fog/softlayer/requests/compute/get_virtual_guest_by_ip.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Matheus Francisco Barra Mina (<mfbmina@gmail.com>)
+# © Copyright IBM Corporation 2015.
+#
+# LICENSE: MIT (http://opensource.org/licenses/MIT)
+#
+module Fog
+  module Compute
+    class Softlayer
+      class Mock
+        def get_virtual_guest_by_ip(ip_address)
+          response = Excon::Response.new
+          response.body = @virtual_guests.map {|vm| vm if vm['public_ip_address'] == ip_address }.compact.first || {}
+          response.status = response.body.empty? ? 404 : 200
+          if response.status == 404
+            response.body = {
+              "error"=>"Unable to find object with ip of '#{ip_address}'.",
+              "code"=>"SoftLayer_Exception_ObjectNotFound"
+            }
+          end
+          response
+        end
+      end
+
+      class Real
+        def get_virtual_guest_by_ip(ip_address)
+          request(:virtual_guest, :findByIpAddress, :body => "#{ip_address}", :http_method => :POST, :query => 'objectMask=mask[datacenter,tagReferences,blockDevices,blockDeviceTemplateGroup.globalIdentifier,operatingSystem.softwareLicense.softwareDescription.referenceCode,sshKeys.id,privateNetworkOnlyFlag,userData,frontendNetworkComponents,backendNetworkComponents]')
+        end
+      end
+    end
+  end
+end

--- a/tests/softlayer/requests/compute/bmc_tests.rb
+++ b/tests/softlayer/requests/compute/bmc_tests.rb
@@ -23,9 +23,17 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
     tests("#create_bare_metal_server('#{@bmc}')") do
       response = @sl_connection.create_bare_metal_server(@bmc)
       @server_id = response.body['id']
+      @server_ip = response.body.first['public_ip_address']
       data_matches_schema(Softlayer::Compute::Formats::BareMetal::SERVER, {:allow_extra_keys => true}) { response.body }
       data_matches_schema(201) { response.status }
     end
+
+    tests"#get_bare_metal_server_by_ip('#{@server_ip}'))" do
+      response = @sl_connection.get_bare_metal_server_by_ip(@server_ip)
+      data_matches_schema(200) { response.status }
+      data_matches_schema(Softlayer::Compute::Formats::BareMetal::SERVER) { response.body }
+    end
+
 
     tests("#get_bare_metal_servers()") do
       @sl_connection.get_bare_metal_servers.body.each do |bms|
@@ -81,6 +89,12 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
 
     tests("#create_bare_metal_server(#{[@bmc]}").raises(ArgumentError) do
       @sl_connection.create_bare_metal_server([@bmc])
+    end
+
+    tests("#get_bare_metal_server_by_ip('1.1.1.1')") do
+      response = @sl_connection.get_bare_metal_server_by_ip('1.1.1.1')
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404){ response.status }
     end
 
     tests("#power_on_bare_metal_server('#{bmc}')") do

--- a/tests/softlayer/requests/compute/bmc_tests.rb
+++ b/tests/softlayer/requests/compute/bmc_tests.rb
@@ -23,7 +23,7 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
     tests("#create_bare_metal_server('#{@bmc}')") do
       response = @sl_connection.create_bare_metal_server(@bmc)
       @server_id = response.body['id']
-      @server_ip = response.body.first['public_ip_address']
+      @server_ip = response.body['primaryIpAddress']
       data_matches_schema(Softlayer::Compute::Formats::BareMetal::SERVER, {:allow_extra_keys => true}) { response.body }
       data_matches_schema(201) { response.status }
     end

--- a/tests/softlayer/requests/compute/vm_tests.rb
+++ b/tests/softlayer/requests/compute/vm_tests.rb
@@ -40,8 +40,15 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
     tests("#create_vm('#{@vm}')") do
       response = @sl_connection.create_vm(@vm)
       @vm_id = response.body.first['id']
+      @vm_ip = response.body.first['public_ip_address']
       #data_matches_schema([Softlayer::Compute::Formats::VirtualGuest::SERVER], {:allow_extra_keys => true}) { response.body }
       data_matches_schema(200) { response.status }
+    end
+
+    tests"#get_virtual_guest_by_ip('#{@vm_ip}'))" do
+      response = @sl_connection.get_virtual_guest_by_ip(@vm_ip)
+      data_matches_schema(200) { response.status }
+      data_matches_schema(Softlayer::Compute::Formats::VirtualGuest::SERVER) { response.body }
     end
 
     tests"#get_vms()" do
@@ -114,6 +121,12 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
 
     tests("#create_vm(#{@vms}").raises(ArgumentError) do
       @sl_connection.create_vm(@vms)
+    end
+
+    tests("#get_virtual_guest_by_ip('1.1.1.1')") do
+      response = @sl_connection.get_virtual_guest_by_ip('1.1.1.1')
+      data_matches_schema('SoftLayer_Exception_ObjectNotFound'){ response.body['code'] }
+      data_matches_schema(404) {response.status}
     end
 
     tests("#power_on_vm('99999999999999')") do

--- a/tests/softlayer/requests/compute/vm_tests.rb
+++ b/tests/softlayer/requests/compute/vm_tests.rb
@@ -40,7 +40,7 @@ Shindo.tests("Fog::Compute[:softlayer] | server requests", ["softlayer"]) do
     tests("#create_vm('#{@vm}')") do
       response = @sl_connection.create_vm(@vm)
       @vm_id = response.body.first['id']
-      @vm_ip = response.body.first['public_ip_address']
+      @vm_ip = response.body.first['primaryIpAddress']
       #data_matches_schema([Softlayer::Compute::Formats::VirtualGuest::SERVER], {:allow_extra_keys => true}) { response.body }
       data_matches_schema(200) { response.status }
     end


### PR DESCRIPTION
Softlayer API has the option for get a virtual_guest or hardware_server using his ip address.

I created two requests called "get_virtual_guest_by_ip" and "get_bare_metal_server_by_ip' and wrapped them into a method on servers called 'get_by_ip' that works like the default get.