### PR TITLE
Adding support for IBM Bluemix Object Storage v1

### DIFF
--- a/examples/storage.md
+++ b/examples/storage.md
@@ -10,6 +10,23 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	@sl = Fog::Storage[:softlayer]
 ```
 
+#### Create a connection within a Bluemix Application to Bluemix v1 Object Storage
+
+```ruby
+	require 'fog/softlayer'
+	objstor_service = JSON.parse(ENV['VCAP_SERVICES'])["objectstorage"].first["credentials"]
+	bluemix_app_name = JSON.parse(ENV["VCAP_APPLICATION"])["name"]
+
+	@sl = Fog::Storage.new({
+	   :provider => 'softlayer',
+	   :softlayer_username => objstor_service['username'].to_s,
+	   :softlayer_api_key => objstor_service['password'].to_s,
+	   :softlayer_storage_account => bluemix_app_name, 
+	   :softlayer_bluemix_objstor_auth_url => objstor_service['auth_uri'].to_s,
+	   :softlayer_cluster => 'dal05'
+	})
+```
+
 #### Use the Models
 1. List directories/containers.
 


### PR DESCRIPTION
Added an extra softlayer_bluemix_objstor_auth_url parameter.  If this parameter is populated, it allows for alternate basic authentication headers required by the Bluemix Object Store v1 service, otherwise defaulting to the existing auth header constructs.  Where possible, the existing softlayer storage parameters are reused to minimize impact to the existing code.  With this support, fog storage compatible gems such as Paperclip are useable within Bluemix CloudFoundry deployed apps.