### PR TITLE
Back out change not allowing using image_id

### DIFF
--- a/lib/fog/softlayer/models/compute/server.rb
+++ b/lib/fog/softlayer/models/compute/server.rb
@@ -494,7 +494,7 @@ module Fog
 
         def validate_attributes
           requires :name, :domain, :cpu, :ram, :datacenter
-          requires_one :os_code if self.attributes[:os_code].nil? # need this while os_code bug isn't fixed
+          requires_one :os_code, :image_id
           requires_one :disk, :image_id
           bare_metal? and image_id and raise ArgumentError, "Bare Metal Cloud does not support booting from Image"
         end


### PR DESCRIPTION
Hello,

So this fixes https://github.com/fog/fog-softlayer/issues/71. So I'm not sure what the os_code bug was exactly, but I've used this branch to launch both Windows and Linux servers without issue.

If you'd like me to do some additional research/testing or have any other issues, let me know!