### PR TITLE
check keys before accessing them

### DIFF
--- a/lib/fog/softlayer/network.rb
+++ b/lib/fog/softlayer/network.rb
@@ -170,7 +170,7 @@ module Fog
         # @return [Integer]
         def global_ipv4_price_code
           request(:product_package, '0/get_item_prices', :query => 'objectMask=mask[id,item.description,categories.id]').body.map do |item|
-            item['id'] if item['categories'][0]['id'] == global_ipv4_cat_code
+            item['id'] if item.has_key?('categories') && !item['categories'][0].nil? && item['categories'][0]['id'] == global_ipv4_cat_code
           end.compact.first
         end
 


### PR DESCRIPTION
The code assumed all responses have a key `categories` but I found a couple examples that did not.  So this change fixes that assumption.

Good Response:
```
 {"id"=>50957, "categories"=>[{"id"=>55}], "item"=>{"description"=>"Load Balancer 1,000 VIP Connections"}},
```

Bad Response:
```
 {"id"=>45742, "item"=>{"description"=>"FortiGate Security Appliance - AV Add-on (High Availability)\t"}},
```