### PR TITLE
New HSM model returns empty array for RAM

### DIFF
--- a/lib/fog/softlayer/models/compute/server.rb
+++ b/lib/fog/softlayer/models/compute/server.rb
@@ -216,7 +216,7 @@ module Fog
         end
 
         def ram=(set)
-          if set.is_a?(Array) and set.first['hardwareComponentModel']
+          if set.is_a?(Array) and !set.empty? and set.first['hardwareComponentModel']
             set = 1024 * set.first['hardwareComponentModel']['capacity'].to_i
           end
           attributes[:ram] = set


### PR DESCRIPTION
Empty array for RAM on HSM breaks server list. Adding check to skip that.