### PR TITLE
Replace `blank?` with standard Ruby code

### DIFF
--- a/lib/fog/softlayer/models/compute/servers.rb
+++ b/lib/fog/softlayer/models/compute/servers.rb
@@ -41,7 +41,7 @@ module Fog
         ## Get a SoftLayer server by ip.
         #
         def get_by_ip(ip)
-          return nil if ip.blank?
+          return nil if ip.to_s.empty?
           response = service.get_virtual_guest_by_ip(ip)
           bare_metal = false
           if response.status == 404 # we didn't find it as a VM, look for a BMC server


### PR DESCRIPTION
`blank?` is from [active_support](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/blank.rb#L18), so this class fails unless `active_support` is required elsewhere.

This patch provides a version that has no external dependencies.