### PR TITLE
Fix compatibility with fog-core 2.x.

### DIFF
--- a/examples/compute.md
+++ b/examples/compute.md
@@ -40,11 +40,11 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	prod_fe_servers = @sl.servers.tagged_with(['production', 'frontend'])
-	# => [ <Fog::Compute::Softlayer::Server>,
-	#	<Fog::Compute::Softlayer::Server>,
-	#	<Fog::Compute::Softlayer::Server>,
-	#	<Fog::Compute::Softlayer::Server>,
-	#	<Fog::Compute::Softlayer::Server>,]		
+	# => [ <Fog::Softlayer::Compute::Server>,
+	#	<Fog::Softlayer::Compute::Server>,
+	#	<Fog::Softlayer::Compute::Server>,
+	#	<Fog::Softlayer::Compute::Server>,
+	#	<Fog::Softlayer::Compute::Server>,]
 	```
    
 1. Get a server's public/frontend VLAN
@@ -52,14 +52,14 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	```ruby
 	server = @sl.servers.get(12345)
 	server.vlan
-	# => <Fog::Network::Softlayer::Network
+	# => <Fog::Softlayer::Network::Network
     #	id=123456,
 	#   name='frontend-staging-vlan',
 	#   modify_date="2014-02-22T12:42:31-06:00",
 	#   note=nil,
 	#   tags=['sparkle', 'motion'],
 	#   type="STANDARD",
-	#   datacenter=    <Fog::Network::Softlayer::Datacenter
+	#   datacenter=    <Fog::Softlayer::Network::Datacenter
 	#     id=168642,
 	#     long_name="San Jose 1",
 	#     name="sjc01"
@@ -74,14 +74,14 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	```ruby
 	server = @sl.servers.get(12345)
 	server.private_vlan
-	# =>  <Fog::Network::Softlayer::Network
+	# =>  <Fog::Softlayer::Network::Network
 	#    id=123456,
 	#    name='backend-staging-vlan',
 	#    modify_date="2014-02-22T12:42:33-06:00",
 	#    note=nil,
 	#    tags=[],
 	#    type="STANDARD",
-	#    datacenter=    <Fog::Network::Softlayer::Datacenter
+	#    datacenter=    <Fog::Softlayer::Network::Datacenter
 	#	    id=168642,
 	#    	long_name="San Jose 1",
 	#    	name="sjc01"
@@ -212,9 +212,9 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	the_first_key = @sl.key_pairs.by_label('my-new-key')
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
 	the_second_key = @sl.key_pairs.by_label('my-other-new-key')
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
 	
 	opts = { 
 		:flavor_id => 'm1.small', 
@@ -224,7 +224,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 		:key_pairs => [ the_first_key, the_second_key ]
 	}
 	@sl.servers.create(opts)
-	# => <Fog::Compute::Softlayer::Server>
+	# => <Fog::Softlayer::Compute::Server>
 ```
 
 
@@ -239,7 +239,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	```ruby
 	# I want to launch another server to hold docker containers into my existing staging VLANs
 	# I'll start by getting a staging server so I can use its vlans as a reference.
-	staging_server = @sl.servers.tagged_with(['staging', 'docker']).first # => <Fog::Compute::Softlayer::Server>
+	staging_server = @sl.servers.tagged_with(['staging', 'docker']).first # => <Fog::Softlayer::Compute::Server>
 	
 	opts = {
 	  :flavor_id => 'm1.large', 
@@ -247,12 +247,12 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	  :domain => 'staging.example.com',
 	  :datacenter => 'ams01', # This needs to be the same datacenter as the target VLAN of course.
 	  :name => 'additional-docker-host',
-	  :vlan => staging.server.vlan, # Passing in a <Fog::Network::Softlayer::Network> object.
+	  :vlan => staging.server.vlan, # Passing in a <Fog::Softlayer::Network::Network> object.
 	  :private_vlan => staging.server.private_vlan.id, # Passing in an Integer (the id of a network/vlan) works too. 
 	}
 
 	new_staging_server = @sl.servers.create(opts)
-	# => <Fog::Compute::Softlayer::Server>
+	# => <Fog::Softlayer::Compute::Server>
 	
 	
 	```
@@ -270,7 +270,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	}
 	
 	private_vm = @sl.servers.create(opts)
-	# => <Fog::Compute::Softlayer::Server>
+	# => <Fog::Softlayer::Compute::Server>
 	```
 1. Provision a Server with 1Gbps network components.
 
@@ -285,7 +285,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	}
 	
 	private_vm = @sl.servers.create(opts)
-	# => <Fog::Compute::Softlayer::Server>
+	# => <Fog::Softlayer::Compute::Server>
 	```
 
 1. Provision a Server with user metadata.

--- a/examples/dns.md
+++ b/examples/dns.md
@@ -72,7 +72,7 @@ or using the service:
 
 ##### Update Operations
 
-After this point we consider you have a Fog::DNS::Softlayer::Domain on @domain variable
+After this point we consider you have a Fog::Softlayer::DNS::Domain on @domain variable
 
 * Update Record Entry
 
@@ -84,7 +84,7 @@ After this point we consider you have a Fog::DNS::Softlayer::Domain on @domain v
 
 ##### Destroy Operations
 
-After this point we consider you have a Fog::DNS::Softlayer::Domain on @domain variable
+After this point we consider you have a Fog::Softlayer::DNS::Domain on @domain variable
 
 * Destroy Domain
 

--- a/examples/global_ip_address.md
+++ b/examples/global_ip_address.md
@@ -9,11 +9,11 @@ require 'fog/softlayer'
 @sl = Fog::Network[:softlayer]
 ```
 
-Global IP addresses are accessed through the `Fog::Network::Softlayer::Ip` model.  Unlike "normal" IP addresses they can be specifically created and destroyed (non-global IP addresses are created/destroyed via a subnet).
+Global IP addresses are accessed through the `Fog::Softlayer::Network::Ip` model.  Unlike "normal" IP addresses they can be specifically created and destroyed (non-global IP addresses are created/destroyed via a subnet).
 
    ```ruby
     global_ips = @network.ips.select { |ip| ip.global? }
-    # => [ <Fog::Network::Softlayer::Ip
+    # => [ <Fog::Softlayer::Network::Ip
     #  id=123456789,
     #  subnet_id=123456,
     #  address="203.0.113.5",
@@ -26,7 +26,7 @@ Global IP addresses are accessed through the `Fog::Network::Softlayer::Ip` model
     #  note=nil,
     #  assigned_to=nil
     # >,
-	# <Fog::Network::Softlayer::Ip
+	# <Fog::Softlayer::Network::Ip
     #  id=123456790,
     #  subnet_id=123457,
     #  address="203.0.113.6",
@@ -35,7 +35,7 @@ Global IP addresses are accessed through the `Fog::Network::Softlayer::Ip` model
     #  network=false,
     #  reserved=false,
     #  global_id=1235,
-    #  destination_ip= <Fog::Network::Softlayer::Ip
+    #  destination_ip= <Fog::Softlayer::Network::Ip
     #    id=123458,
     #    subnet_id=123456,
     #    address="203.0.113.7",
@@ -61,7 +61,7 @@ Route an unrouted global IP to a specific server:
 
 ```ruby
 global_ip = @network.ips.select { |ip| ip.global? && !ip.routed? }.first
-# => <Fog::Network::Softlayer::Ip
+# => <Fog::Softlayer::Network::Ip
 #  id=123456789,
 #  subnet_id=123456,
 #  address="203.0.113.5",
@@ -78,14 +78,14 @@ global_ip.routed? # => false
 
 
 @compute = Fog::Compute[:softlayer]
-dest_server = @compute.servers.tagged_with(['production', 'frontend', 'hkg']).first # => <Fog::Compute::Softlayer::Server>
-dest_ip = @network.ips.by_address(dest_server.public_ip_address) # => <Fog::Network::Softlayer::Ip>
+dest_server = @compute.servers.tagged_with(['production', 'frontend', 'hkg']).first # => <Fog::Softlayer::Compute::Server>
+dest_ip = @network.ips.by_address(dest_server.public_ip_address) # => <Fog::Softlayer::Network::Ip>
 
 
 global_ip.route(dest_ip) # => true
 
 global_ip.reload
-# => <Fog::Network::Softlayer::Ip
+# => <Fog::Softlayer::Network::Ip
 #  id=123456789,
 #  subnet_id=123456,
 #  address="203.0.113.5",
@@ -94,7 +94,7 @@ global_ip.reload
 #  network=false,
 #  reserved=false,
 #  global_id=1234,
-#  destination_ip= <Fog::Network::Softlayer::Ip
+#  destination_ip= <Fog::Softlayer::Network::Ip
 #    id=123458,
 #    subnet_id=123456,
 #    address="203.0.113.8",
@@ -121,11 +121,11 @@ That same address to a different server:
 global_ip = @network.ips.by_address('203.0.113.5')
 global_ip.destination.address # => 203.0.113.8
 
-london_server = @compute.servers.tagged_with(['production', 'frontend', 'lon']).first # => <Fog::Compute::Softlayer::Server>
-dest_ip = @network.ips.by_address(london_server.public_ip_address) # => <Fog::Network::Softlayer::Ip>
+london_server = @compute.servers.tagged_with(['production', 'frontend', 'lon']).first # => <Fog::Softlayer::Compute::Server>
+dest_ip = @network.ips.by_address(london_server.public_ip_address) # => <Fog::Softlayer::Network::Ip>
 
 global_ip.route(dest_ip) # => true
-global_ip.reload # => <Fog::Network::Softlayer::Ip>
+global_ip.reload # => <Fog::Softlayer::Network::Ip>
 global_ip.destination.address # => 203.0.113.9
 ```
 
@@ -135,7 +135,7 @@ global_ip = @network.ips.by_address('203.0.113.5')
 global_ip.routed? # => true
 
 global_ip.unroute # => true
-global_ip.reload # => <Fog::Network::Softlayer::Ip>
+global_ip.reload # => <Fog::Softlayer::Network::Ip>
 
 global_ip.routed? # => false
 ```
@@ -143,12 +143,12 @@ global_ip.routed? # => false
 Create new IPv4:
 *Note:* these methods are blocking and can take several seconds to respond.
 ```ruby
-@network.create_new_global_ipv4 # => <Fog::Network::Softlayer::Ip>
+@network.create_new_global_ipv4 # => <Fog::Softlayer::Network::Ip>
 ```
 
 Create new IPv6:
 ```ruby
-@network.create_new_global_ipv6 # => <Fog::Network::Softlayer::Ip>
+@network.create_new_global_ipv6 # => <Fog::Softlayer::Network::Ip>
 ```
 
 Destroy a global IP address:

--- a/examples/key_pairs.md
+++ b/examples/key_pairs.md
@@ -15,12 +15,12 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
    ```ruby
 	kp1 = @sl.key_pairs.create(:label => 'my-new-key', :key => 'ssh-rsa AAAAxbU2lx...')
-   # => <Fog::Compute::Softlayer::KeyPair>
+   # => <Fog::Softlayer::Compute::KeyPair>
 	kp2 = @sl.key_pairs.new
 	kp2.label = 'my-new-new-key'
 	kp2.key = 'ssh-rsa AAAAxbU2lx...'
 	kp2.save
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
    ```
 
 1. Get
@@ -28,11 +28,11 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	```ruby
 	# By id:
 	kp = @sl.key_pairs.get(123456)
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
 
 	# By label:
 	kp = @sl.key_pairs.by_label('my-new-key')
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
 	```
 
 
@@ -40,7 +40,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	kp = @sl.key_pairs.by_label('my-new-key')
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
 	kp.destroy
 	```
 
@@ -50,9 +50,9 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	the_first_key = @sl.key_pairs.by_label('my-new-key')
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
 	the_second_key = @sl.key_pairs.by_label('my-other-new-key')
-	# => <Fog::Compute::Softlayer::KeyPair>
+	# => <Fog::Softlayer::Compute::KeyPair>
 	
 	opts = { 
 		:flavor_id => 'm1.small', 
@@ -62,7 +62,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 		:key_pairs => [ the_first_key, the_second_key ]
 	}
 	@sl.servers.create(opts)
-	# => <Fog::Compute::Softlayer::Server>
+	# => <Fog::Softlayer::Compute::Server>
 ```
 
 1. Look at the key pairs on a server.
@@ -70,6 +70,6 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	```ruby
 	server = @sl.servers.get(12345)
 	server.key_pairs
-	# => [ <Fog::Compute::Softlayer::Server>,
-	# <Fog::Compute::Softlayer::Server>]
+	# => [ <Fog::Softlayer::Compute::Server>,
+	# <Fog::Softlayer::Compute::Server>]
 	```

--- a/examples/network.md
+++ b/examples/network.md
@@ -15,14 +15,14 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
    ```ruby
     nets = @sl.networks
-    # => [ <Fog::Network::Softlayer::Network
+    # => [ <Fog::Softlayer::Network::Network
     #  	id=123456,
     #	name="some-optional-name",
     #	modify_date="2014-06-25T17:10:57-05:00",
     #	note=nil,
     #	tags=["sparkle", "motion", "public"],
     #	type="STANDARD",
-    #	datacenter=	<Fog::Network::Softlayer::Datacenter
+    #	datacenter=	<Fog::Softlayer::Network::Datacenter
     #		id=12345,
     #		long_name="Washington, DC 1",
     #		name="wdc01"
@@ -30,14 +30,14 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
     #	network_space="PUBLIC"
     #	router={"hostname"=>"fcr02.wdc01", "id"=>40378, "datacenter"=>{"id"=>37473, "longName"=>"Washington, DC 1", "name"=>"wdc01"}}
     #	>,
-    #	<Fog::Network::Softlayer::Network
+    #	<Fog::Softlayer::Network::Network
     #	id=123457,
     #	name="some-other-optional-name",
     #	modify_date="2014-06-25T17:11:57-05:00",
     #	note=nil,
     #	tags=["sparkle", "motion", "private"],
     #	type="STANDARD",
-    #	datacenter=	<Fog::Network::Softlayer::Datacenter
+    #	datacenter=	<Fog::Softlayer::Network::Datacenter
     #		id=12345,
     #		long_name="Washington, DC 1",
     #		name="wdc01"
@@ -52,14 +52,14 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	net = @sl.networks.get(123456)
-	# => <Fog::Network::Softlayer::Network
+	# => <Fog::Softlayer::Network::Network
     #	id=123456,
     #	name="some-name",
     #	modify_date="2014-06-25T17:10:57-05:00",
     #	note=nil,
     #	tags=["sparkle", "motion", "public"],
     #	type="STANDARD",
-    #	datacenter=	<Fog::Network::Softlayer::Datacenter
+    #	datacenter=	<Fog::Softlayer::Network::Datacenter
     #		id=12345,
     #		long_name="Washington, DC 1",
     #		name="wdc01"
@@ -73,14 +73,14 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	@sl.networks.by_name('some-name')
-	# => <Fog::Network::Softlayer::Network
+	# => <Fog::Softlayer::Network::Network
     #	id=123456,
     #	name="some-name",
     #	modify_date="2014-06-25T17:10:57-05:00",
     #	note=nil,
     #	tags=["sparkle", "motion", "public"],
     #	type="STANDARD",
-    #	datacenter=	<Fog::Network::Softlayer::Datacenter
+    #	datacenter=	<Fog::Softlayer::Network::Datacenter
     #		id=12345,
     #		long_name="Washington, DC 1",
     #		name="wdc01"
@@ -94,9 +94,9 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	prod_backend_nets = @sl.networks.tagged_with(['production', 'private'])
-	# => [<Fog::Network::Softlayer::Network>,
-	#	<Fog::Network::Softlayer::Network>,
-	#	<Fog::Network::Softlayer::Network>,
+	# => [<Fog::Softlayer::Network::Network>,
+	#	<Fog::Softlayer::Network::Network>,
+	#	<Fog::Softlayer::Network::Network>,
 	#	]    	
 	```
 	
@@ -123,7 +123,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	```ruby
 		net = @sl.networks.get(123456)
 		net.subnets
-		# => [  <Fog::Network::Softlayer::Subnet
+		# => [  <Fog::Softlayer::Network::Subnet
 	    # id=123456,
 	    # name=nil,
 	    # network_id="37.58.125.72",
@@ -136,7 +136,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	    # gateway=nil,
     	# datacenter="ams01"
 	  # >,
-	   # <Fog::Network::Softlayer::Subnet
+	   # <Fog::Softlayer::Network::Subnet
 	    # id=123457,
     	# name=nil,
 	    # network_id="81.95.147.148",
@@ -157,12 +157,12 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 		net = @sl.networks.get(123456)
 		# Here I'm selecting the primary subnet...
 		subnet = net.subnets.select { |vlan| vlan.type == "PRIMARY" }.first
-		# => <Fog::Network::Softlayer::Subnet
+		# => <Fog::Softlayer::Network::Subnet
 	    # id=123457,
 	    # ...
 	    # >
 	    addys = subnet.addresses
-	    # => [  <Fog::Network::Softlayer::Ip
+	    # => [  <Fog::Softlayer::Network::Ip
    		 # id=19222174,
 	     # subnet_id=630962,
 	     # address="37.58.125.72",
@@ -173,7 +173,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 	     # note=nil,
 	     # assigned_to=nil
 		 # >,
-		# <Fog::Network::Softlayer::Ip
+		# <Fog::Softlayer::Network::Ip
    		 #  id=19222174,
 		 #  subnet_id=630962,
 		 #  address="37.58.125.73",
@@ -184,7 +184,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 		 #  note=nil,
 		 #  assigned_to=nil
 		 #  >,
-		# <Fog::Network::Softlayer::Ip
+		# <Fog::Softlayer::Network::Ip
    		 #  id=19222174,
 		 #  subnet_id=630962,
 		 #  address="37.58.125.74",
@@ -195,7 +195,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 		 #  note=nil,
 		 #  assigned_to={"fullyQualifiedDomainName"=>"hostname.example.com", "id"=>281730}
 		 #  >,
-		# <Fog::Network::Softlayer::Ip
+		# <Fog::Softlayer::Network::Ip
    		 #  id=19222174,
 		 #  subnet_id=630962,
 		 #  address="37.58.125.75",

--- a/examples/storage.md
+++ b/examples/storage.md
@@ -84,7 +84,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
   ```ruby
    @sl.directories.get('a-container').files
    # => [
-   #    <Fog::Storage::Softlayer::File
+   #    <Fog::Softlayer::Storage::File
    #  key="a-container/data.txt",
    #  content_length=43,
    #  content_type="text/plain",

--- a/examples/tags.md
+++ b/examples/tags.md
@@ -43,24 +43,24 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 1. Get servers tagged by a single tag.
 
    ```ruby
-   	@sl.servers.tagged_with(['foo']) # => [<Fog::Compute::Softlayer::Server>, <Fog::Compute::Softlayer::Server>, ...]
+   	@sl.servers.tagged_with(['foo']) # => [<Fog::Softlayer::Compute::Server>, <Fog::Softlayer::Compute::Server>, ...]
    ```
 
 1. Get servers tagged by multiple tags (tag OR tag OR ...).
 
    ```ruby
-   	@sl.servers.tagged_with(['foo','bar']) # => [<Fog::Compute::Softlayer::Server>, <Fog::Compute::Softlayer::Server>, ...]
+   	@sl.servers.tagged_with(['foo','bar']) # => [<Fog::Softlayer::Compute::Server>, <Fog::Softlayer::Compute::Server>, ...]
    ```
 
 1. List all tags on account that have been assigned to a server.
 
    ```ruby
-   	  @sl.tags.all # => [<Fog::Compute::Softlayer::Tag>, <Fog::Compute::Softlayer::Tag>, ...]
+   	  @sl.tags.all # => [<Fog::Softlayer::Compute::Tag>, <Fog::Softlayer::Compute::Tag>, ...]
      ```
 1. Anatomy of a Tag object.
 
 	```ruby
-	<Fog::Compute::Softlayer::Tag
+	<Fog::Softlayer::Compute::Tag
     id=32850, # SoftLayer assigned ID
     name="sparkle", # the tag itself
     referenceCount=2, # number of SL API objects that "have" this tag
@@ -73,7 +73,7 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	tag = @sl.tags.get(32850)
-	tag.references # => [<Fog::Compute::Softlayer::Server>, <Fog::Compute::Softlayer::Server>, ...]
+	tag.references # => [<Fog::Softlayer::Compute::Server>, <Fog::Softlayer::Compute::Server>, ...]
 	```
 	
 #### Create a connection to SoftLayer Network Service
@@ -117,24 +117,24 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 1. Get networks tagged by a single tag.
 
    ```ruby
-   	@sl.networks.tagged_with(['foo']) # => [<Fog::Network::Softlayer::Network>, <Fog::Network::Softlayer::Network>, ...]
+   	@sl.networks.tagged_with(['foo']) # => [<Fog::Softlayer::Network::Network>, <Fog::Softlayer::Network::Network>, ...]
    ```
 
 1. Get networks tagged by multiple tags (tag OR tag OR ...).
 
    ```ruby
-   	@sl.networks.tagged_with(['foo','bar']) # => [<Fog::Network::Softlayer::Network>, <Fog::Network::Softlayer::Network>, ...]
+   	@sl.networks.tagged_with(['foo','bar']) # => [<Fog::Softlayer::Network::Network>, <Fog::Softlayer::Network::Network>, ...]
    ```
 
 1. List all tags on account that have been assigned to a network.
 
    ```ruby
-   	  @sl.tags.all # => [<Fog::Network::Softlayer::Network>, <Fog::Network::Softlayer::Network>, ...]
+   	  @sl.tags.all # => [<Fog::Softlayer::Network::Network>, <Fog::Softlayer::Network::Network>, ...]
      ```
 1. Anatomy of a Tag object.
 
 	```ruby
-	<Fog::Network::Softlayer::Tag
+	<Fog::Softlayer::Network::Tag
     id=32850, # SoftLayer assigned ID
     name="sparkle", # the tag itself
     referenceCount=2, # number of SL API objects that "have" this tag
@@ -147,6 +147,6 @@ If you are unfamiliar with fog, we recommend reading our [getting started](getti
 
 	```ruby
 	tag = @sl.tags.get(32850)
-	tag.references # => [<Fog::Network::Softlayer::Network>, <Fog::Network::Softlayer::Network>, ...]
+	tag.references # => [<Fog::Softlayer::Network::Network>, <Fog::Softlayer::Network::Network>, ...]
 	```
 

--- a/fog-softlayer.gemspec
+++ b/fog-softlayer.gemspec
@@ -2,6 +2,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fog/softlayer/version'
+require 'date'
 
 Gem::Specification.new do |spec|
   spec.name          = "fog-softlayer"

--- a/lib/fog/softlayer.rb
+++ b/lib/fog/softlayer.rb
@@ -13,28 +13,14 @@ require File.expand_path('../softlayer/ext/string', __FILE__)
 require File.expand_path('../softlayer/ext/hash', __FILE__) unless {}.respond_to? :deep_merge
 
 module Fog
-  module Account
-    autoload :Softlayer, File.expand_path('../softlayer/account', __FILE__)
-  end
-
-  module Compute
-    autoload :Softlayer, File.expand_path('../softlayer/compute', __FILE__)
-  end
-
-  module DNS
-    autoload :Softlayer, File.expand_path('../softlayer/dns', __FILE__)
-  end
-
-  module Network
-    autoload :Softlayer, File.expand_path('../softlayer/network', __FILE__)
-  end
-
-  module Storage
-    autoload :Softlayer, File.expand_path('../softlayer/storage', __FILE__)
-  end
-
   module Softlayer
     extend Fog::Provider
+
+    autoload :Account, File.expand_path('../softlayer/account', __FILE__)
+    autoload :Compute, File.expand_path('../softlayer/compute', __FILE__)
+    autoload :DNS, File.expand_path('../softlayer/dns', __FILE__)
+    autoload :Network, File.expand_path('../softlayer/network', __FILE__)
+    autoload :Storage, File.expand_path('../softlayer/storage', __FILE__)
 
     autoload :Product, File.expand_path('../softlayer/product', __FILE__)
     autoload :Slapi, File.expand_path('../softlayer/slapi', __FILE__)

--- a/lib/fog/softlayer/account.rb
+++ b/lib/fog/softlayer/account.rb
@@ -5,11 +5,9 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 
-require 'fog/softlayer/compute/shared'
-
 module Fog
-  module Account
-    class Softlayer < Fog::Service
+  module Softlayer
+    class Account < Fog::Service
       # Client credentials
       requires :softlayer_username, :softlayer_api_key
 

--- a/lib/fog/softlayer/compute.rb
+++ b/lib/fog/softlayer/compute.rb
@@ -5,11 +5,12 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 
-require 'fog/softlayer/compute/shared'
 
 module Fog
-  module Compute
-    class Softlayer < Fog::Service
+  module Softlayer
+    class Compute < Fog::Service
+      require 'fog/softlayer/compute/shared'
+
       class MissingRequiredParameter < Fog::Errors::Error; end
 
       # Client credentials

--- a/lib/fog/softlayer/compute/shared.rb
+++ b/lib/fog/softlayer/compute/shared.rb
@@ -7,7 +7,7 @@
 
 module Fog
   module Softlayer
-    module Compute
+    class Compute
 
       # The Shared module consists of code that was duplicated between the Real
       # and Mock implementations.

--- a/lib/fog/softlayer/dns.rb
+++ b/lib/fog/softlayer/dns.rb
@@ -5,11 +5,9 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 
-require 'fog/softlayer/compute/shared'
-
 module Fog
-  module DNS
-    class Softlayer < Fog::Service
+  module Softlayer
+    class DNS < Fog::Service
       class MissingRequiredParameter < Fog::Errors::Error; end
 
       # Client credentials

--- a/lib/fog/softlayer/models/account/brand.rb
+++ b/lib/fog/softlayer/models/account/brand.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Brand < Fog::Model
         identity  :id, :type => :integer
         attribute :catalog_id, :aliases => 'catalogId', :type => :integer

--- a/lib/fog/softlayer/models/account/brands.rb
+++ b/lib/fog/softlayer/models/account/brands.rb
@@ -8,10 +8,10 @@
 require 'fog/softlayer/models/account/brand'
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Brands < Fog::Collection
-        model Fog::Account::Softlayer::Brand
+        model Fog::Softlayer::Account::Brand
 
         def all
           data = service.get_account_owned_brands

--- a/lib/fog/softlayer/models/compute/flavor.rb
+++ b/lib/fog/softlayer/models/compute/flavor.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Flavor < Fog::Model
 

--- a/lib/fog/softlayer/models/compute/flavors.rb
+++ b/lib/fog/softlayer/models/compute/flavors.rb
@@ -8,8 +8,8 @@
 require 'fog/softlayer/models/compute/flavor'
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       ## SoftLayer doesn't actually have "flavors", these are just for portability/convenience,
       # they map directly to OpenStack defaults.
@@ -58,13 +58,13 @@ module Fog
 
       class Flavors < Fog::Collection
 
-        model Fog::Compute::Softlayer::Flavor
+        model Fog::Softlayer::Compute::Flavor
 
         # Returns an array of all flavors that have been created
         #
         # Fog::Softlayer.flavors.all
         def all
-          load(Fog::Compute::Softlayer::FLAVORS)
+          load(Fog::Softlayer::Compute::FLAVORS)
           self
         end
 

--- a/lib/fog/softlayer/models/compute/image.rb
+++ b/lib/fog/softlayer/models/compute/image.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Image < Fog::Model
 

--- a/lib/fog/softlayer/models/compute/images.rb
+++ b/lib/fog/softlayer/models/compute/images.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/compute/image'
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Images < Fog::Collection
 
-        model Fog::Compute::Softlayer::Image
+        model Fog::Softlayer::Compute::Image
 
         # Returns an array of all public images.
         #

--- a/lib/fog/softlayer/models/compute/key_pair.rb
+++ b/lib/fog/softlayer/models/compute/key_pair.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class KeyPair < Fog::Model
         identity :id
 

--- a/lib/fog/softlayer/models/compute/key_pairs.rb
+++ b/lib/fog/softlayer/models/compute/key_pairs.rb
@@ -8,10 +8,10 @@
 require 'fog/softlayer/models/compute/key_pair'
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class KeyPairs < Fog::Collection
-        model Fog::Compute::Softlayer::KeyPair
+        model Fog::Softlayer::Compute::KeyPair
 
         def all
           data = service.get_key_pairs.body
@@ -22,7 +22,7 @@ module Fog
           if key_pair = service.get_key_pair(id).body
             new(key_pair)
           end
-        rescue Fog::Network::Softlayer::NotFound
+        rescue Fog::Softlayer::Network::NotFound
           nil
         end
 

--- a/lib/fog/softlayer/models/compute/network_component.rb
+++ b/lib/fog/softlayer/models/compute/network_component.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class NetworkComponent < Fog::Model
         identity :id
 

--- a/lib/fog/softlayer/models/compute/network_components.rb
+++ b/lib/fog/softlayer/models/compute/network_components.rb
@@ -8,10 +8,10 @@
 require 'fog/softlayer/models/compute/key_pair'
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class NetworkComponents < Fog::Collection
-        model Fog::Compute::Softlayer::NetworkComponent
+        model Fog::Softlayer::Compute::NetworkComponent
 
         # just a stub
 

--- a/lib/fog/softlayer/models/compute/server.rb
+++ b/lib/fog/softlayer/models/compute/server.rb
@@ -8,8 +8,8 @@
 require 'fog/compute/models/server'
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Server < Fog::Compute::Server
 
@@ -166,8 +166,8 @@ module Fog
         end
 
         def private_vlan=(value)
-          unless value.is_a?(Integer) or value.is_a?(Fog::Network::Softlayer::Network)
-            raise ArgumentError, "vlan argument for #{self.class.name}##{__method__} must be Integer or Fog::Network::Softlayer::Network."
+          unless value.is_a?(Integer) or value.is_a?(Fog::Softlayer::Network::Network)
+            raise ArgumentError, "vlan argument for #{self.class.name}##{__method__} must be Integer or Fog::Softlayer::Network::Network."
           end
           value = network_connection.networks.get(value) if value.is_a?(Integer)
           attributes[:private_vlan] = value
@@ -195,10 +195,10 @@ module Fog
             ## This was nice but causing an intolerable number of requests on an account with lots of keys.
             ## ToDo: something better...
             #key = self.symbolize_keys(key) if key.is_a?(Hash)
-            #unless key.is_a?(Fog::Compute::Softlayer::KeyPair) or (key.is_a?(Hash) and key[:id])
-            #  raise ArgumentError, "Elements of keys array for #{self.class.name}##{__method__} must be a Hash with key 'id', or Fog::Compute::Softlayer::KeyPair"
+            #unless key.is_a?(Fog::Softlayer::Compute::KeyPair) or (key.is_a?(Hash) and key[:id])
+            #  raise ArgumentError, "Elements of keys array for #{self.class.name}##{__method__} must be a Hash with key 'id', or Fog::Softlayer::Compute::KeyPair"
             #end
-            #key = service.key_pairs.get(key[:id]) unless key.is_a?(Fog::Compute::Softlayer::KeyPair)
+            #key = service.key_pairs.get(key[:id]) unless key.is_a?(Fog::Softlayer::Compute::KeyPair)
             attributes[:key_pairs] << key
           end
         end
@@ -208,8 +208,8 @@ module Fog
         end
 
         def vlan=(value)
-          unless value.is_a?(Integer) or value.is_a?(Fog::Network::Softlayer::Network)
-            raise ArgumentError, "vlan argument for #{self.class.name}##{__method__} must be Integer or Fog::Network::Softlayer::Network."
+          unless value.is_a?(Integer) or value.is_a?(Fog::Softlayer::Network::Network)
+            raise ArgumentError, "vlan argument for #{self.class.name}##{__method__} must be Integer or Fog::Softlayer::Network::Network."
           end
           value = network_connection.networks.get(value) if value.is_a?(Integer)
           attributes[:vlan] = value
@@ -249,7 +249,7 @@ module Fog
 
         def public_network_components
           if attributes['frontendNetworkComponents']
-            attributes['frontendNetworkComponents'].map { |n| Fog::Compute::Softlayer::NetworkComponent.new(n) }
+            attributes['frontendNetworkComponents'].map { |n| Fog::Softlayer::Compute::NetworkComponent.new(n) }
           else
             []
           end
@@ -257,7 +257,7 @@ module Fog
 
         def private_network_components
           if attributes['backendNetworkComponents']
-            attributes['backendNetworkComponents'].map { |n| Fog::Compute::Softlayer::NetworkComponent.new(n) }
+            attributes['backendNetworkComponents'].map { |n| Fog::Softlayer::Compute::NetworkComponent.new(n) }
           else
             []
           end

--- a/lib/fog/softlayer/models/compute/servers.rb
+++ b/lib/fog/softlayer/models/compute/servers.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/compute/server'
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Servers < Fog::Collection
 
-        model Fog::Compute::Softlayer::Server
+        model Fog::Softlayer::Compute::Server
 
         def all
           data = service.list_servers

--- a/lib/fog/softlayer/models/compute/tag.rb
+++ b/lib/fog/softlayer/models/compute/tag.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Tag < Fog::Model
         identity  :id
 

--- a/lib/fog/softlayer/models/compute/tags.rb
+++ b/lib/fog/softlayer/models/compute/tags.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/compute/tag'
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Tags < Fog::Collection
         attribute :filters
 
-        model Fog::Compute::Softlayer::Tag
+        model Fog::Softlayer::Compute::Tag
 
         def initialize(attributes)
           self.filters ||= []

--- a/lib/fog/softlayer/models/dns/domain.rb
+++ b/lib/fog/softlayer/models/dns/domain.rb
@@ -8,8 +8,8 @@
 require 'fog/softlayer/models/dns/records'
 
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Domain < Fog::Model
 
@@ -27,7 +27,7 @@ module Fog
         def records(reload = false)
           @records = nil if reload
           @records ||= begin
-            Fog::DNS::Softlayer::Records.new(
+            Fog::Softlayer::DNS::Records.new(
               :domain       => self,
               :service      => service
             )
@@ -36,7 +36,7 @@ module Fog
         
         def create_record(opts = {})
           opts.merge!({:domain_id => self.id, :service => service})
-          record = Fog::DNS::Softlayer::Record.new(opts)
+          record = Fog::Softlayer::DNS::Record.new(opts)
           record.save
           records(true)
           record

--- a/lib/fog/softlayer/models/dns/domains.rb
+++ b/lib/fog/softlayer/models/dns/domains.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/compute/server'
 
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Domains < Fog::Collection
 
-        model Fog::DNS::Softlayer::Domain
+        model Fog::Softlayer::DNS::Domain
 
         def all
           data = service.get_domains.body

--- a/lib/fog/softlayer/models/dns/record.rb
+++ b/lib/fog/softlayer/models/dns/record.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
       class Record < Fog::Model
         identity  :id
         attribute :domain_id,     :aliases => "domainId"

--- a/lib/fog/softlayer/models/dns/records.rb
+++ b/lib/fog/softlayer/models/dns/records.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/dns/record'
 
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
       class Records < Fog::Collection
         attribute :domain
 
-        model Fog::DNS::Softlayer::Record
+        model Fog::Softlayer::DNS::Record
 
         def all
           requires :domain

--- a/lib/fog/softlayer/models/network/datacenter.rb
+++ b/lib/fog/softlayer/models/network/datacenter.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Datacenter < Fog::Model
         identity :id
 

--- a/lib/fog/softlayer/models/network/datacenters.rb
+++ b/lib/fog/softlayer/models/network/datacenters.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/network/datacenter'
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Datacenters < Fog::Collection
         attribute :filters
 
-        model Fog::Network::Softlayer::Datacenter
+        model Fog::Softlayer::Network::Datacenter
 
         def initialize(attributes)
           self.filters ||= {}
@@ -28,7 +28,7 @@ module Fog
         def get(id)
           data = service.request(:location_datacenter, "#{id}/get_object").body
             new.merge_attributes(data)
-        rescue Fog::Network::Softlayer::NotFound
+        rescue Fog::Softlayer::Network::NotFound
           nil
         end
 

--- a/lib/fog/softlayer/models/network/ip.rb
+++ b/lib/fog/softlayer/models/network/ip.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Ip < Fog::Model
         identity :id
 
@@ -42,8 +42,8 @@ module Fog
 
         def destination_ip=(ip)
           if ip.is_a?(Hash)
-            attributes[:destination_ip] = Fog::Network::Softlayer::Ip.new(ip)
-          elsif ip.is_a?(Fog::Network::Softlayer::Ip) or ip.nil?
+            attributes[:destination_ip] = Fog::Softlayer::Network::Ip.new(ip)
+          elsif ip.is_a?(Fog::Softlayer::Network::Ip) or ip.nil?
             attributes[:destination_ip] = ip
           else
             raise ArgumentError, "Invalid argument type in #{self.class.name}##{__method__}."
@@ -77,7 +77,7 @@ module Fog
 
         def route(dest_ip)
           requires :global_id
-          raise ArgumentError, "Invalid argument type in #{self.class.name}##{__method__}." unless dest_ip.is_a?(Fog::Network::Softlayer::Ip)
+          raise ArgumentError, "Invalid argument type in #{self.class.name}##{__method__}." unless dest_ip.is_a?(Fog::Softlayer::Network::Ip)
           raise ArgumentError, "The destination IP may not be the network address of the destination subnet" if dest_ip.network?
           raise ArgumentError, "The destination IP may not be the gateway address of the destination subnet" if dest_ip.gateway?
           raise ArgumentError, "The destination IP may not be the broadcast address of the destination subnet" if dest_ip.broadcast?

--- a/lib/fog/softlayer/models/network/ips.rb
+++ b/lib/fog/softlayer/models/network/ips.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/network/ip'
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Ips < Fog::Collection
         attribute :filters
 
-        model Fog::Network::Softlayer::Ip
+        model Fog::Softlayer::Network::Ip
 
         def initialize(attributes)
           self.filters ||= {}
@@ -50,7 +50,7 @@ module Fog
 
           new(ip) if ip
 
-        rescue Fog::Network::Softlayer::NotFound
+        rescue Fog::Softlayer::Network::NotFound
           nil
         end
 

--- a/lib/fog/softlayer/models/network/network.rb
+++ b/lib/fog/softlayer/models/network/network.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Network < Fog::Model
         identity :id
 

--- a/lib/fog/softlayer/models/network/networks.rb
+++ b/lib/fog/softlayer/models/network/networks.rb
@@ -8,10 +8,10 @@
 require 'fog/softlayer/models/network/network'
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Networks < Fog::Collection
-        model Fog::Network::Softlayer::Network
+        model Fog::Softlayer::Network::Network
 
         def all
           data = service.list_networks.body
@@ -22,7 +22,7 @@ module Fog
           if network = service.get_network(id).body
             new(network)
           end
-        rescue Fog::Network::Softlayer::NotFound
+        rescue Fog::Softlayer::Network::NotFound
           nil
         end
 

--- a/lib/fog/softlayer/models/network/subnet.rb
+++ b/lib/fog/softlayer/models/network/subnet.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Subnet < Fog::Model
         identity :id
 

--- a/lib/fog/softlayer/models/network/subnets.rb
+++ b/lib/fog/softlayer/models/network/subnets.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/network/subnet'
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Subnets < Fog::Collection
         attribute :filters
 
-        model Fog::Network::Softlayer::Subnet
+        model Fog::Softlayer::Network::Subnet
 
         def all
           load(service.list_subnets.body)
@@ -23,7 +23,7 @@ module Fog
           if subnet = service.get_subnet(id).body
             new(subnet)
           end
-        rescue Fog::Network::Softlayer::NotFound
+        rescue Fog::Softlayer::Network::NotFound
           nil
         end
       end

--- a/lib/fog/softlayer/models/network/tag.rb
+++ b/lib/fog/softlayer/models/network/tag.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Tag < Fog::Model
         identity  :id
 

--- a/lib/fog/softlayer/models/network/tags.rb
+++ b/lib/fog/softlayer/models/network/tags.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/network/tag'
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Tags < Fog::Collection
         attribute :filters
 
-        model Fog::Network::Softlayer::Tag
+        model Fog::Softlayer::Network::Tag
 
         def initialize(attributes)
           self.filters ||= []

--- a/lib/fog/softlayer/models/storage/directories.rb
+++ b/lib/fog/softlayer/models/storage/directories.rb
@@ -8,12 +8,12 @@
 require 'fog/softlayer/models/storage/directory'
 
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
 
       class Directories < Fog::Collection
 
-        model Fog::Storage::Softlayer::Directory
+        model Fog::Softlayer::Storage::Directory
 
         def all
           data = service.get_containers.body
@@ -34,7 +34,7 @@ module Fog
             directory.files << directory.files.new(file)
           end
           directory
-        rescue Fog::Storage::Softlayer::NotFound
+        rescue Fog::Softlayer::Storage::NotFound
           nil
         end
 

--- a/lib/fog/softlayer/models/storage/directory.rb
+++ b/lib/fog/softlayer/models/storage/directory.rb
@@ -8,8 +8,8 @@
 require 'fog/softlayer/models/storage/files'
 
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
 
       class Directory < Fog::Model
 
@@ -29,7 +29,7 @@ module Fog
 
         def files
           @files ||= begin
-            Fog::Storage::Softlayer::Files.new(
+            Fog::Softlayer::Storage::Files.new(
               :directory    => self,
               :service   => service
             )

--- a/lib/fog/softlayer/models/storage/file.rb
+++ b/lib/fog/softlayer/models/storage/file.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
 
       class File < Fog::Model
 

--- a/lib/fog/softlayer/models/storage/files.rb
+++ b/lib/fog/softlayer/models/storage/files.rb
@@ -8,8 +8,8 @@
 require 'fog/softlayer/models/storage/file'
 
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
 
       class Files < Fog::Collection
 
@@ -19,7 +19,7 @@ module Fog
         attribute :path
         attribute :prefix
 
-        model Fog::Storage::Softlayer::File
+        model Fog::Softlayer::Storage::File
 
         def all(options = {})
           requires :directory
@@ -66,7 +66,7 @@ module Fog
             :key  => key
           })
           new(file_data)
-        rescue Fog::Storage::Softlayer::NotFound
+        rescue Fog::Softlayer::Storage::NotFound
           nil
         end
 
@@ -89,7 +89,7 @@ module Fog
             :key => key
           })
           new(file_data)
-        rescue Fog::Storage::Softlayer::NotFound
+        rescue Fog::Softlayer::Storage::NotFound
           nil
         end
 

--- a/lib/fog/softlayer/network.rb
+++ b/lib/fog/softlayer/network.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer < Fog::Service
+  module Softlayer
+    class Network < Fog::Service
 
       requires :softlayer_username, :softlayer_api_key
 

--- a/lib/fog/softlayer/product.rb
+++ b/lib/fog/softlayer/product.rb
@@ -5,8 +5,6 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 
-require 'fog/softlayer/compute/shared'
-
 module Fog
   module Softlayer
     class Product < Fog::Service

--- a/lib/fog/softlayer/requests/account/create_brand.rb
+++ b/lib/fog/softlayer/requests/account/create_brand.rb
@@ -6,14 +6,14 @@
 #
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Mock
         # Create a Brand
         # @param [Hash] attributes
         # @return [Excon::Response]
         def create_brand(attributes)
-          raise ArgumentError, "Fog::Account::Softlayer#create_brand expects argument of type Hash" unless attributes.kind_of?(Hash)
+          raise ArgumentError, "Fog::Softlayer#Account::create_brand expects argument of type Hash" unless attributes.kind_of?(Hash)
           response = Excon::Response.new
           required = %w{keyName longName name account}
           if Fog::Softlayer.valid_request?(required, attributes)

--- a/lib/fog/softlayer/requests/account/get_account_owned_brands.rb
+++ b/lib/fog/softlayer/requests/account/get_account_owned_brands.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Mock
         # Get all brands who are owned by account.
         # @param [Integer] identifier
@@ -38,8 +38,8 @@ module Fog
 end
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Mock
         def mocked_brands
           [

--- a/lib/fog/softlayer/requests/account/get_brand.rb
+++ b/lib/fog/softlayer/requests/account/get_brand.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Mock
         # Get a Brand
         # @param [Integer] identifier

--- a/lib/fog/softlayer/requests/account/get_brand_owned_accounts.rb
+++ b/lib/fog/softlayer/requests/account/get_brand_owned_accounts.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Mock
         # Get all accounts who are owned by brand.
         # @param [Integer] identifier
@@ -39,8 +39,8 @@ end
 
 
 module Fog
-  module Account
-    class Softlayer
+  module Softlayer
+    class Account
       class Mock
         def mocked_accounts
           [

--- a/lib/fog/softlayer/requests/compute/create_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/create_bare_metal_server.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 
@@ -33,7 +33,7 @@ module Fog
         #   Defaults to false, pass true for a single-tenant VM.
         # @return [Excon::Response]
         def create_bare_metal_server(opts)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_bare_metal_server expects argument of type Hash" unless opts.kind_of?(Hash)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_bare_metal_server expects argument of type Hash" unless opts.kind_of?(Hash)
           response = Excon::Response.new
           required = %w{hostname domain processorCoreAmount memoryCapacity hourlyBillingFlag operatingSystemReferenceCode}
 
@@ -76,7 +76,7 @@ module Fog
       class Real
 
         def create_bare_metal_server(opts)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_bare_metal_server expects argument of type Hash" unless opts.kind_of?(Hash)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_bare_metal_server expects argument of type Hash" unless opts.kind_of?(Hash)
           request(:hardware_server, :create_object, :body => opts, :http_method => :POST)
         end
 

--- a/lib/fog/softlayer/requests/compute/create_bare_metal_tags.rb
+++ b/lib/fog/softlayer/requests/compute/create_bare_metal_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def create_bare_metal_tags(id, tags = [])

--- a/lib/fog/softlayer/requests/compute/create_key_pair.rb
+++ b/lib/fog/softlayer/requests/compute/create_key_pair.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/create_vm.rb
+++ b/lib/fog/softlayer/requests/compute/create_vm.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 
@@ -33,7 +33,7 @@ module Fog
         #   Defaults to false, pass true for a single-tenant VM.
         # @return [Excon::Response]
         def create_vm(opts)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_vm expects argument of type Hash" unless opts.kind_of?(Hash)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_vm expects argument of type Hash" unless opts.kind_of?(Hash)
           opts = [opts]
           self.create_vms(opts)
         end
@@ -42,7 +42,7 @@ module Fog
 
       class Real
         def create_vm(opts)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_vm expects argument of type Hash" unless opts.kind_of?(Hash)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_vm expects argument of type Hash" unless opts.kind_of?(Hash)
           opts = [[opts]] # don't ask...
           self.create_vms(opts)
         end

--- a/lib/fog/softlayer/requests/compute/create_vm_tags.rb
+++ b/lib/fog/softlayer/requests/compute/create_vm_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def create_vm_tags(id, tags = [])

--- a/lib/fog/softlayer/requests/compute/create_vms.rb
+++ b/lib/fog/softlayer/requests/compute/create_vms.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 
@@ -33,7 +33,7 @@ module Fog
         #   Defaults to false, pass true for a single-tenant VM.
         # @return [Excon::Response]
         def create_vms(opts)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_vms expects argument of type Array" unless opts.kind_of?(Array)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_vms expects argument of type Array" unless opts.kind_of?(Array)
           response = Excon::Response.new
           required = %w{hostname domain startCpus maxMemory hourlyBillingFlag localDiskFlag}
 
@@ -87,7 +87,7 @@ module Fog
 
       class Real
         def create_vms(opts)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_vms expects argument of type Array" unless opts.kind_of?(Array)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_vms expects argument of type Array" unless opts.kind_of?(Array)
           request(:virtual_guest, :create_objects, :body => opts, :http_method => :POST)
         end
       end

--- a/lib/fog/softlayer/requests/compute/delete_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/delete_bare_metal_server.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/delete_bare_metal_tags.rb
+++ b/lib/fog/softlayer/requests/compute/delete_bare_metal_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/delete_key_pair.rb
+++ b/lib/fog/softlayer/requests/compute/delete_key_pair.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/delete_vm.rb
+++ b/lib/fog/softlayer/requests/compute/delete_vm.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/delete_vm_tags.rb
+++ b/lib/fog/softlayer/requests/compute/delete_vm_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/describe_tags.rb
+++ b/lib/fog/softlayer/requests/compute/describe_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/generate_bare_metal_order_template.rb
+++ b/lib/fog/softlayer/requests/compute/generate_bare_metal_order_template.rb
@@ -5,14 +5,14 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Generate an order template for a Bare Metal
         # @param [Integer] order_template
         # @return [Excon::Response]
         def generate_bare_metal_order_template(order_template)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_vms expects argument of type Hash" unless order_template.kind_of?(Hash)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_vms expects argument of type Hash" unless order_template.kind_of?(Hash)
           response = Excon::Response.new
           required = %w{hostname domain processorCoreAmount memoryCapacity hourlyBillingFlag operatingSystemReferenceCode}
           begin
@@ -41,8 +41,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def order_template_mock
           {

--- a/lib/fog/softlayer/requests/compute/generate_virtual_guest_order_template.rb
+++ b/lib/fog/softlayer/requests/compute/generate_virtual_guest_order_template.rb
@@ -5,14 +5,14 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Generate an order template for a Virtual Guest
         # @param [Integer] order_template
         # @return [Excon::Response]
         def generate_virtual_guest_order_template(order_template)
-          raise ArgumentError, "Fog::Compute::Softlayer#create_vms expects argument of type Hash" unless order_template.kind_of?(Hash)
+          raise ArgumentError, "Fog::Softlayer#Compute::create_vms expects argument of type Hash" unless order_template.kind_of?(Hash)
           response = Excon::Response.new
           required = %w{hostname domain startCpus maxMemory hourlyBillingFlag localDiskFlag}
           begin
@@ -41,8 +41,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def order_template_mock
           {

--- a/lib/fog/softlayer/requests/compute/get_available_preset_codes.rb
+++ b/lib/fog/softlayer/requests/compute/get_available_preset_codes.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_available_preset_codes
           {

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_active_tickets.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_active_tickets.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Bare Metal active tickets
         # @param [Integer] id
@@ -38,8 +38,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_active_tickets
           [

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_create_options.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_create_options.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Bare Metal buy options
         # @return [Excon::Response]
@@ -28,8 +28,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def bare_metal_options
           {

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_server.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def get_bare_metal_server(identifier)

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_server_by_ip.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_server_by_ip.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_bare_metal_server_by_ip(ip_address)
           response = Excon::Response.new

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_servers.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_servers.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def get_bare_metal_servers

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_tags.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_upgrade_item_prices.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_upgrade_item_prices.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Bare Metal upgrade item prices
         # @param [Integer] id
@@ -38,8 +38,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_upgrade_options
             [

--- a/lib/fog/softlayer/requests/compute/get_bare_metal_users.rb
+++ b/lib/fog/softlayer/requests/compute/get_bare_metal_users.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Bare Metal users
         # @param [Integer] id
@@ -38,8 +38,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_users
           [

--- a/lib/fog/softlayer/requests/compute/get_key_pair.rb
+++ b/lib/fog/softlayer/requests/compute/get_key_pair.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def get_key_pair(id)

--- a/lib/fog/softlayer/requests/compute/get_key_pairs.rb
+++ b/lib/fog/softlayer/requests/compute/get_key_pairs.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def get_key_pairs

--- a/lib/fog/softlayer/requests/compute/get_references_by_tag_name.rb
+++ b/lib/fog/softlayer/requests/compute/get_references_by_tag_name.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/get_tag.rb
+++ b/lib/fog/softlayer/requests/compute/get_tag.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/get_virtual_guest_active_tickets.rb
+++ b/lib/fog/softlayer/requests/compute/get_virtual_guest_active_tickets.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Virtual Guest active tickets
         # @param [Integer] id
@@ -38,8 +38,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_active_tickets
           [

--- a/lib/fog/softlayer/requests/compute/get_virtual_guest_by_ip.rb
+++ b/lib/fog/softlayer/requests/compute/get_virtual_guest_by_ip.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_virtual_guest_by_ip(ip_address)
           response = Excon::Response.new

--- a/lib/fog/softlayer/requests/compute/get_virtual_guest_create_options.rb
+++ b/lib/fog/softlayer/requests/compute/get_virtual_guest_create_options.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Virtual Guest buy options
         # @return [Excon::Response]
@@ -28,8 +28,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def virtual_guest_options
           {

--- a/lib/fog/softlayer/requests/compute/get_virtual_guest_upgrade_item_prices.rb
+++ b/lib/fog/softlayer/requests/compute/get_virtual_guest_upgrade_item_prices.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Virtual Guest upgrade item prices
         # @param [Integer] id
@@ -38,8 +38,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_upgrade_item_prices
           [

--- a/lib/fog/softlayer/requests/compute/get_virtual_guest_users.rb
+++ b/lib/fog/softlayer/requests/compute/get_virtual_guest_users.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         # Gets all Virtual Guest users
         # @param [Integer] id
@@ -38,8 +38,8 @@ module Fog
 end
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
       class Mock
         def get_users
           [

--- a/lib/fog/softlayer/requests/compute/get_vm.rb
+++ b/lib/fog/softlayer/requests/compute/get_vm.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def get_vm(identifier)

--- a/lib/fog/softlayer/requests/compute/get_vm_tags.rb
+++ b/lib/fog/softlayer/requests/compute/get_vm_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/get_vms.rb
+++ b/lib/fog/softlayer/requests/compute/get_vms.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
         def get_vms

--- a/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_off_bare_metal_server.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/power_off_vm.rb
+++ b/lib/fog/softlayer/requests/compute/power_off_vm.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/power_on_bare_metal_server.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/power_on_vm.rb
+++ b/lib/fog/softlayer/requests/compute/power_on_vm.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
+++ b/lib/fog/softlayer/requests/compute/reboot_bare_metal_server.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/reboot_vm.rb
+++ b/lib/fog/softlayer/requests/compute/reboot_vm.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/compute/update_key_pair.rb
+++ b/lib/fog/softlayer/requests/compute/update_key_pair.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module Compute
-    class Softlayer
+  module Softlayer
+    class Compute
 
       class Mock
 

--- a/lib/fog/softlayer/requests/dns/create_domain.rb
+++ b/lib/fog/softlayer/requests/dns/create_domain.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def create_domain(opts)

--- a/lib/fog/softlayer/requests/dns/create_record.rb
+++ b/lib/fog/softlayer/requests/dns/create_record.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def create_record(opts)

--- a/lib/fog/softlayer/requests/dns/delete_domain.rb
+++ b/lib/fog/softlayer/requests/dns/delete_domain.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def delete_domain(id)

--- a/lib/fog/softlayer/requests/dns/delete_record.rb
+++ b/lib/fog/softlayer/requests/dns/delete_record.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def delete_record(id)

--- a/lib/fog/softlayer/requests/dns/get_domain.rb
+++ b/lib/fog/softlayer/requests/dns/get_domain.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def get_domain(id)

--- a/lib/fog/softlayer/requests/dns/get_domain_by_name.rb
+++ b/lib/fog/softlayer/requests/dns/get_domain_by_name.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def get_domain_by_name(name)

--- a/lib/fog/softlayer/requests/dns/get_domains.rb
+++ b/lib/fog/softlayer/requests/dns/get_domains.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def get_domains

--- a/lib/fog/softlayer/requests/dns/get_record.rb
+++ b/lib/fog/softlayer/requests/dns/get_record.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def get_record(id)

--- a/lib/fog/softlayer/requests/dns/get_records.rb
+++ b/lib/fog/softlayer/requests/dns/get_records.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def get_records(domain_id)

--- a/lib/fog/softlayer/requests/dns/update_record.rb
+++ b/lib/fog/softlayer/requests/dns/update_record.rb
@@ -5,8 +5,8 @@
 # LICENSE: MIT (http://opensource.org/licenses/MIT)
 #
 module Fog
-  module DNS
-    class Softlayer
+  module Softlayer
+    class DNS
 
       class Mock
         def update_record(record_id, opts)

--- a/lib/fog/softlayer/requests/network/create_network.rb
+++ b/lib/fog/softlayer/requests/network/create_network.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
         def create_network(order)

--- a/lib/fog/softlayer/requests/network/create_network_tags.rb
+++ b/lib/fog/softlayer/requests/network/create_network_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
         def create_network_tags(id, tags = [])

--- a/lib/fog/softlayer/requests/network/create_subnet.rb
+++ b/lib/fog/softlayer/requests/network/create_subnet.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
         def create_subnet(order)

--- a/lib/fog/softlayer/requests/network/delete_global_ip_address.rb
+++ b/lib/fog/softlayer/requests/network/delete_global_ip_address.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/delete_network.rb
+++ b/lib/fog/softlayer/requests/network/delete_network.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/delete_network_tags.rb
+++ b/lib/fog/softlayer/requests/network/delete_network_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_datacenter_routers.rb
+++ b/lib/fog/softlayer/requests/network/get_datacenter_routers.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_datacenters.rb
+++ b/lib/fog/softlayer/requests/network/get_datacenters.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_global_ip_address.rb
+++ b/lib/fog/softlayer/requests/network/get_global_ip_address.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_global_ip_records.rb
+++ b/lib/fog/softlayer/requests/network/get_global_ip_records.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_ip_address.rb
+++ b/lib/fog/softlayer/requests/network/get_ip_address.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_ip_addresses.rb
+++ b/lib/fog/softlayer/requests/network/get_ip_addresses.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_maintenance_windows.rb
+++ b/lib/fog/softlayer/requests/network/get_maintenance_windows.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Mock
         def get_maintenance_windows(location_id, begin_date, end_date, slots_number)
           raise ArgumentError, "Arguments for #{self.class.name}##{__method__} must be present." if begin_date.nil? || end_date.nil? || location_id.nil? || slots_number.nil?
@@ -29,8 +29,8 @@ module Fog
 end
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
       class Mock
         def get_windows
           [

--- a/lib/fog/softlayer/requests/network/get_network.rb
+++ b/lib/fog/softlayer/requests/network/get_network.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_network_tags.rb
+++ b/lib/fog/softlayer/requests/network/get_network_tags.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_portable_subnet_package_id.rb
+++ b/lib/fog/softlayer/requests/network/get_portable_subnet_package_id.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_portable_subnet_price_code.rb
+++ b/lib/fog/softlayer/requests/network/get_portable_subnet_price_code.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_private_vlan_price_code.rb
+++ b/lib/fog/softlayer/requests/network/get_private_vlan_price_code.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_public_vlan_price_code.rb
+++ b/lib/fog/softlayer/requests/network/get_public_vlan_price_code.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_references_by_tag_name.rb
+++ b/lib/fog/softlayer/requests/network/get_references_by_tag_name.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_subnet.rb
+++ b/lib/fog/softlayer/requests/network/get_subnet.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_subnet_package_id.rb
+++ b/lib/fog/softlayer/requests/network/get_subnet_package_id.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/get_subnet_price_code.rb
+++ b/lib/fog/softlayer/requests/network/get_subnet_price_code.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/list_networks.rb
+++ b/lib/fog/softlayer/requests/network/list_networks.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/list_subnets.rb
+++ b/lib/fog/softlayer/requests/network/list_subnets.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/route_global_ip.rb
+++ b/lib/fog/softlayer/requests/network/route_global_ip.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/network/unroute_global_ip.rb
+++ b/lib/fog/softlayer/requests/network/unroute_global_ip.rb
@@ -6,8 +6,8 @@
 #
 
 module Fog
-  module Network
-    class Softlayer
+  module Softlayer
+    class Network
 
       class Mock
 

--- a/lib/fog/softlayer/requests/storage/copy_object.rb
+++ b/lib/fog/softlayer/requests/storage/copy_object.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def copy_object(source_container, source_object, target_container, target_object, options={})
           response = Excon::Response.new

--- a/lib/fog/softlayer/requests/storage/delete_container.rb
+++ b/lib/fog/softlayer/requests/storage/delete_container.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def delete_container(name)
           response = Excon::Response.new

--- a/lib/fog/softlayer/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/softlayer/requests/storage/delete_multiple_objects.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # Deletes multiple objects or containers with a single request.

--- a/lib/fog/softlayer/requests/storage/delete_object.rb
+++ b/lib/fog/softlayer/requests/storage/delete_object.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
 
         def delete_object(container, object)

--- a/lib/fog/softlayer/requests/storage/delete_static_large_object.rb
+++ b/lib/fog/softlayer/requests/storage/delete_static_large_object.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # Delete a static large object.

--- a/lib/fog/softlayer/requests/storage/get_container.rb
+++ b/lib/fog/softlayer/requests/storage/get_container.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def get_container(container, options = {})
           if @containers[container]

--- a/lib/fog/softlayer/requests/storage/get_containers.rb
+++ b/lib/fog/softlayer/requests/storage/get_containers.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def get_containers(options = {})
           response = Excon::Response.new

--- a/lib/fog/softlayer/requests/storage/get_object.rb
+++ b/lib/fog/softlayer/requests/storage/get_object.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def get_object(container, object, &block)
           if @containers[container] && @containers[container][object]

--- a/lib/fog/softlayer/requests/storage/get_object_https_url.rb
+++ b/lib/fog/softlayer/requests/storage/get_object_https_url.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def get_object_https_url(container, object, expires, options = {})
           "https://cluster.objectstorage.softlayer.net:443/v1/AUTH_abcdefghijklmnopqrstuvwxyz/#{container}/#{object}?temp_url_sig=1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a&temp_url_expires=1111111111111"

--- a/lib/fog/softlayer/requests/storage/head_container.rb
+++ b/lib/fog/softlayer/requests/storage/head_container.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # List number of objects and total bytes stored

--- a/lib/fog/softlayer/requests/storage/head_containers.rb
+++ b/lib/fog/softlayer/requests/storage/head_containers.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # List number of containers and total bytes stored

--- a/lib/fog/softlayer/requests/storage/head_object.rb
+++ b/lib/fog/softlayer/requests/storage/head_object.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # Get headers for object

--- a/lib/fog/softlayer/requests/storage/post_set_meta_temp_url_key.rb
+++ b/lib/fog/softlayer/requests/storage/post_set_meta_temp_url_key.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
 
       class Real
 

--- a/lib/fog/softlayer/requests/storage/put_container.rb
+++ b/lib/fog/softlayer/requests/storage/put_container.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def put_container(name, public=false)
           @containers[name] = {} unless @containers[name]

--- a/lib/fog/softlayer/requests/storage/put_dynamic_obj_manifest.rb
+++ b/lib/fog/softlayer/requests/storage/put_dynamic_obj_manifest.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # Create a new dynamic large object manifest

--- a/lib/fog/softlayer/requests/storage/put_object.rb
+++ b/lib/fog/softlayer/requests/storage/put_object.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Mock
         def put_object(container, object, data, options = {}, &block)
           if @containers[container]

--- a/lib/fog/softlayer/requests/storage/put_object_manifest.rb
+++ b/lib/fog/softlayer/requests/storage/put_object_manifest.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # Create a new dynamic large object manifest

--- a/lib/fog/softlayer/requests/storage/put_static_obj_manifest.rb
+++ b/lib/fog/softlayer/requests/storage/put_static_obj_manifest.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Storage
-    class Softlayer
+  module Softlayer
+    class Storage
       class Real
 
         # Create a new static large object manifest.

--- a/lib/fog/softlayer/storage.rb
+++ b/lib/fog/softlayer/storage.rb
@@ -8,8 +8,8 @@
 require 'base64'
 
 module Fog
-  module Storage
-    class Softlayer < Fog::Service
+  module Softlayer
+    class Storage < Fog::Service
       requires :softlayer_username, :softlayer_api_key, :softlayer_cluster
       recognizes :persistent, :softlayer_storage_account, :softlayer_temp_url_key, :softlayer_bluemix_objstor_auth_url
 
@@ -134,7 +134,7 @@ module Fog
           rescue Excon::Errors::HTTPStatusError => error
             raise case error
               when Excon::Errors::NotFound
-                Fog::Storage::Softlayer::NotFound.slurp(error)
+                Fog::Softlayer::Storage::NotFound.slurp(error)
               else
                 error
             end

--- a/spec/fog/compute/softlayer_spec.rb
+++ b/spec/fog/compute/softlayer_spec.rb
@@ -7,7 +7,7 @@
 require "minitest/autorun"
 require "fog/softlayer"
 
-describe Fog::Compute::Softlayer do
+describe Fog::Softlayer::Compute do
   describe "when global config is available" do
     before do
 
@@ -23,7 +23,7 @@ describe Fog::Compute::Softlayer do
       end
 
       Fog.stub :credentials, @credential_guard do
-        @service = Fog::Compute::Softlayer.new(@arguments)
+        @service = Fog::Softlayer::Compute.new(@arguments)
       end
     end
 
@@ -37,7 +37,7 @@ describe Fog::Compute::Softlayer do
     it "raises an error" do
       Fog.stub :credentials, {} do
         assert_raises ArgumentError do
-          Fog::Compute::Softlayer.new({})
+          Fog::Softlayer::Compute.new({})
         end
       end
     end

--- a/tests/softlayer/models/compute/flavor_tests.rb
+++ b/tests/softlayer/models/compute/flavor_tests.rb
@@ -12,11 +12,11 @@ Shindo.tests("Fog::Compute[:softlayer] | Flavor model", ["softlayer"]) do
     @service = Fog::Compute[:softlayer]
 
     tests("#all") do
-      returns(Fog::Compute::Softlayer::Flavor) { @service.flavors.all.first.class }
+      returns(Fog::Softlayer::Compute::Flavor) { @service.flavors.all.first.class }
     end
 
     tests("#get") do
-      returns(Fog::Compute::Softlayer::Flavor) { @service.flavors.get('m1.tiny').class }
+      returns(Fog::Softlayer::Compute::Flavor) { @service.flavors.get('m1.tiny').class }
     end
 
   end

--- a/tests/softlayer/models/compute/image_tests.rb
+++ b/tests/softlayer/models/compute/image_tests.rb
@@ -13,11 +13,11 @@ Shindo.tests("Fog::Compute[:softlayer] | Image model", ["softlayer"]) do
 
     tests("#all") do
       @image = @service.images.all.first
-      returns(Fog::Compute::Softlayer::Image) { @image.class }
+      returns(Fog::Softlayer::Compute::Image) { @image.class }
     end
 
     tests("#get") do
-      returns(Fog::Compute::Softlayer::Image) { @service.images.get(@image.id).class }
+      returns(Fog::Softlayer::Compute::Image) { @service.images.get(@image.id).class }
     end
 
   end

--- a/tests/softlayer/models/compute/key_pair_tests.rb
+++ b/tests/softlayer/models/compute/key_pair_tests.rb
@@ -32,7 +32,7 @@ Shindo.tests("Fog::Compute[:softlayer] | KeyPair model", ["softlayer"]) do
     end
 
     tests("#create(:label => 'test-key-2', :key => #{@key_gen.call}") do
-      data_matches_schema(Fog::Compute::Softlayer::KeyPair) { @sl_connection.key_pairs.create(:label => 'test-key-2', :key => @key_gen.call)}
+      data_matches_schema(Fog::Softlayer::Compute::KeyPair) { @sl_connection.key_pairs.create(:label => 'test-key-2', :key => @key_gen.call)}
     end
 
     tests("#destroy") do

--- a/tests/softlayer/models/dns/domains_tests.rb
+++ b/tests/softlayer/models/dns/domains_tests.rb
@@ -14,7 +14,7 @@ Shindo.tests("Fog::DNS[:softlayer] | Domains model", ["softlayer"]) do
     tests("#create") do
       name = "fog-domain-"+SecureRandom.random_number(36**12).to_s(36).rjust(12, "0") + ".com"
       @domain = @service.domains.create(name)
-      returns(Fog::DNS::Softlayer::Domain) { @service.domains.get(@domain.id).class }
+      returns(Fog::Softlayer::DNS::Domain) { @service.domains.get(@domain.id).class }
       returns(@domain.name, "returns the object with correct name") { @service.domains.get(@domain.id).name }
       @domain.destroy
     end
@@ -33,7 +33,7 @@ Shindo.tests("Fog::DNS[:softlayer] | Domains model", ["softlayer"]) do
       # Tests if we get the 3 domains we created
       @domains = @service.domains.all
       @domains.each do |domain|
-        returns(Fog::DNS::Softlayer::Domain, "returns a "+domain.name) { domain.class }
+        returns(Fog::Softlayer::DNS::Domain, "returns a "+domain.name) { domain.class }
       end
       
       # Check ifs domains we created are included
@@ -56,12 +56,12 @@ Shindo.tests("Fog::DNS[:softlayer] | Domains model", ["softlayer"]) do
     @domain = @service.domains.create(name)
     
     tests("#get") do
-      returns(Fog::DNS::Softlayer::Domain) { @service.domains.get(@domain.id).class }
+      returns(Fog::Softlayer::DNS::Domain) { @service.domains.get(@domain.id).class }
       returns(@domain.name, "returns the object with correct name") { @service.domains.get(@domain.id).name }
     end
     
     tests("#get_by_name") do
-      returns(Fog::DNS::Softlayer::Domain) { @service.domains.get_by_name(@domain.name).class }
+      returns(Fog::Softlayer::DNS::Domain) { @service.domains.get_by_name(@domain.name).class }
       returns(@domain.name, "returns the object with correct name") { @service.domains.get_by_name(@domain.name).name }
     end
     

--- a/tests/softlayer/models/dns/record_tests.rb
+++ b/tests/softlayer/models/dns/record_tests.rb
@@ -40,7 +40,7 @@ Shindo.tests("Fog::DNS[:softlayer] | Record model", ["softlayer"]) do
     
     tests("#get") do
       @record_get = @service.records.get(@record.id)
-      returns(Fog::DNS::Softlayer::Record) { @record_get.class }
+      returns(Fog::Softlayer::DNS::Record) { @record_get.class }
       
       tests("after updating the record") do
         @record_get.value = "192.168.10.1"

--- a/tests/softlayer/models/storage/directory_tests.rb
+++ b/tests/softlayer/models/storage/directory_tests.rb
@@ -15,25 +15,25 @@ Shindo.tests("Fog::Storage[:softlayer] | Directory model", ["softlayer"]) do
     @storage = Fog::Storage[:softlayer]
 
     tests("#create") do
-      data_matches_schema(Fog::Storage::Softlayer::Directory) { @storage.directories.create(:key => @test_dir1) }
+      data_matches_schema(Fog::Softlayer::Storage::Directory) { @storage.directories.create(:key => @test_dir1) }
     end
 
     tests("#get") do
-      data_matches_schema(Fog::Storage::Softlayer::Directory) { @storage.directories.get(@test_dir1) }
+      data_matches_schema(Fog::Softlayer::Storage::Directory) { @storage.directories.get(@test_dir1) }
     end
 
     tests("#all") do
       @storage.directories.create(:key => @test_dir2)
       schema = [
-          Fog::Storage::Softlayer::Directory,
-          Fog::Storage::Softlayer::Directory
+          Fog::Softlayer::Storage::Directory,
+          Fog::Softlayer::Storage::Directory
       ]
       data_matches_schema(schema) { @storage.directories.all }
     end
 
     tests("#destroy") do
       data_matches_schema(true) { @storage.directories.get(@test_dir1).destroy }
-      data_matches_schema([Fog::Storage::Softlayer::Directory]) { @storage.directories.all }
+      data_matches_schema([Fog::Softlayer::Storage::Directory]) { @storage.directories.all }
     end
 
     tests("#public_url") do

--- a/tests/softlayer/models/storage/file_tests.rb
+++ b/tests/softlayer/models/storage/file_tests.rb
@@ -18,25 +18,25 @@ Shindo.tests("Fog::Storage[:softlayer] | File model", ["softlayer"]) do
     @test_file3 = 'test-object-3'
 
     tests("#create") do
-      data_matches_schema(Fog::Storage::Softlayer::File) { @test_dir1.files.create(:key => @test_file1) }
-      data_matches_schema(Fog::Storage::Softlayer::File) { @test_dir1.files.create(:key => @test_file2) }
+      data_matches_schema(Fog::Softlayer::Storage::File) { @test_dir1.files.create(:key => @test_file1) }
+      data_matches_schema(Fog::Softlayer::Storage::File) { @test_dir1.files.create(:key => @test_file2) }
     end
 
     tests("#all") do
       schema = [
-          Fog::Storage::Softlayer::File,
-          Fog::Storage::Softlayer::File
+          Fog::Softlayer::Storage::File,
+          Fog::Softlayer::Storage::File
       ]
       data_matches_schema(schema) { @test_dir1.files.all }
     end
 
     tests("#get") do
-      data_matches_schema(Fog::Storage::Softlayer::File) { @test_dir1.files.get(@test_file1) }
+      data_matches_schema(Fog::Softlayer::Storage::File) { @test_dir1.files.get(@test_file1) }
     end
 
     tests("#copy") do
-      data_matches_schema(Fog::Storage::Softlayer::File) { @test_dir1.files.get(@test_file1).copy(@test_dir2, @test_file1)}
-      data_matches_schema(Fog::Storage::Softlayer::File) { @test_dir2.files.get(@test_file1) }
+      data_matches_schema(Fog::Softlayer::Storage::File) { @test_dir1.files.get(@test_file1).copy(@test_dir2, @test_file1)}
+      data_matches_schema(Fog::Softlayer::Storage::File) { @test_dir2.files.get(@test_file1) }
     end
 
     tests("#destroy") do

--- a/tests/softlayer/storage_tests.rb
+++ b/tests/softlayer/storage_tests.rb
@@ -11,10 +11,10 @@ Shindo.tests('Fog::Storage[:softlayer]', ['softlayer']) do
       mocking = Fog.mocking?
       Fog.unmock!
       # Stubs Real Connection
-      class Fog::Storage::Softlayer::Real
+      class Fog::Softlayer::Storage::Real
         def initialize(_options = {});end
       end
-      @service = Fog::Storage::Softlayer.new(softlayer_username: 'name',
+      @service = Fog::Softlayer::Storage::new(softlayer_username: 'name',
                                              softlayer_api_key: 'key',
                                              softlayer_cluster: 'cluster',
                                              softlayer_storage_account: 'account')


### PR DESCRIPTION
This is PR fixing compatibility with fog-core 2.x. There are basically two changes:

1. Changes in namespacing from namespaces such as `Fog::Compute::Softlayer` to `Fog::Softlayer::Compute`
2. `lib/fog/softlayer/compute/shared` is now loaded just in `lib/fog/softlayer/compute.rb` to allow proper autoloading of `Fog::Softlayer::Compute` class.

The test suite is passing for me. I did not tested anything else.